### PR TITLE
Overhaul search with fzf-style fuzzy DSL, JSON output, and typo fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,13 +206,16 @@ dependencies = [
  "chrono",
  "clap",
  "dirs",
+ "nucleo-matcher",
  "regex",
  "reqwest",
  "serde",
  "serde_json",
  "sha2",
+ "strsim",
  "tempfile",
  "thiserror",
+ "unicode-normalization",
  "uuid",
  "walkdir",
 ]
@@ -796,6 +799,16 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nucleo-matcher"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf33f538733d1a5a3494b836ba913207f14d9d4a1d3cd67030c5061bdd2cac85"
+dependencies = [
+ "memchr",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -1460,6 +1473,21 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,15 @@ base64 = "0.22"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.5", features = ["derive"] }
 dirs = "6.0"
+nucleo-matcher = "0.3.1"
 regex = "1.12.3"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
+strsim = "0.11.1"
 thiserror = "2.0"
+unicode-normalization = "0.1.22"
 uuid = { version = "1.18", features = ["v4", "serde"] }
 walkdir = "2.5"
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ cargo install --path .
 clawgallery init
 clawgallery folder add ~/Desktop
 clawgallery bootstrap
-clawgallery search screenshot
+clawgallery search screenshot --json
 clawgallery caption --dry-run
 clawgallery rename --dry-run
 ```
@@ -88,10 +88,28 @@ clawgallery bootstrap [--folder <id>] [--path <path>] [--prune]
 clawgallery poll [--once] [--interval <seconds>] [--prune]
 clawgallery caption [--missing] [--file <path>] [--dry-run] [--model <model>] [--provider <provider>]
 clawgallery rename [--apply] [--dry-run] [--file <path>] [--style title|caption|date-title] [--force]
-clawgallery search <keywords...> [--limit <n>]
+clawgallery search <query...> [--limit <n>] [--json] [--case-sensitive] [--no-fuzzy]
 clawgallery status
 clawgallery skill path|print
 ```
+
+## Search syntax
+
+`clawgallery search` scans the local JSONL state on every invocation and ranks matches by weighted fields: title matches outrank description matches, which outrank path-only matches. The default text output includes the familiar path/title/caption lines plus `score:` and `matches:` lines. Agents and brittle scripts should prefer `--json` for JSONL records, or `--no-fuzzy` to preserve the old exact substring output format.
+
+Queries use nucleo/fzf-style operators:
+
+| Syntax | Meaning | Example |
+|---|---|---|
+| `foo bar` | AND-match both atoms fuzzily | `clawgallery search login error` |
+| `'foo` | Exact substring atom | `clawgallery search "'github"` |
+| `^foo` | Prefix atom | `clawgallery search ^Login` |
+| `foo$` | Suffix atom | `clawgallery search modal$` |
+| `!foo` | Exclude substring | `clawgallery search login !test` |
+| `!^foo`, `!foo$` | Exclude prefix/suffix | `clawgallery search !^Draft` |
+| `\ ` | Literal space inside an atom | `clawgallery search github\ actions` |
+
+Lowercase queries use smart-case matching; any uppercase atom becomes case-sensitive. Pass `--case-sensitive` to force case-sensitive matching. If the fuzzy pass returns no candidates, ClawGallery falls back to token/window typo tolerance for atoms of at least three characters. `--no-fuzzy` disables the DSL, fuzzy scoring, typo fallback, sorting, and score/matches output for compatibility with old scripts.
 
 ## Rename safety
 

--- a/skills/clawgallery/SKILL.md
+++ b/skills/clawgallery/SKILL.md
@@ -29,7 +29,11 @@ Search known screenshots:
 ```bash
 clawgallery search login error
 clawgallery search "github actions" --limit 5
+clawgallery search "'github" "actions" --json
+clawgallery search "!error" "^login"
 ```
+
+Search supports fzf-style atoms: whitespace means AND, `'foo` means exact substring, `^foo` means prefix, `foo$` means suffix, `!foo` excludes a substring, and `\ ` escapes a literal space inside one atom. Default text output includes score/matches metadata; use `--no-fuzzy` for the old exact substring format.
 
 Caption uncaptured images:
 
@@ -83,7 +87,7 @@ The three steps are deliberately separated so cheap, free, idempotent indexing (
 
 ## Agent guidance
 
-1. Prefer `search` before asking the user to locate screenshots manually.
+1. Prefer `search --json` before asking the user to locate screenshots manually; JSONL is the stable output for agents.
 2. Use `caption --dry-run` to see pending work when model credentials may be absent.
 3. Never pass `--apply` to rename unless the user requested actual file changes or an approved workflow requires it.
 4. If a command needs isolated state, set `CLAWGALLERY_CONFIG_DIR` to a task-specific temporary directory.

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,10 @@ use anyhow::{Context, Result, anyhow, bail};
 use base64::Engine;
 use chrono::{DateTime, Utc};
 use clap::{Args, Parser, Subcommand, ValueEnum};
+use nucleo_matcher::{
+    Config, Matcher, Utf32Str,
+    pattern::{CaseMatching, Normalization, Pattern},
+};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
@@ -15,6 +19,7 @@ use std::{
     thread,
     time::Duration,
 };
+use unicode_normalization::UnicodeNormalization;
 use uuid::Uuid;
 use walkdir::WalkDir;
 
@@ -156,9 +161,20 @@ enum RenameStyle {
 
 #[derive(Debug, Args)]
 struct SearchArgs {
+    /// Query terms (combined as fzf-style query). See README for syntax.
     keywords: Vec<String>,
+    /// Maximum number of results to print.
     #[arg(long, default_value_t = 20)]
     limit: usize,
+    /// Emit one JSON object per result (JSONL).
+    #[arg(long)]
+    json: bool,
+    /// Force case-sensitive matching (overrides smart-case).
+    #[arg(long)]
+    case_sensitive: bool,
+    /// Disable fuzzy matching and Levenshtein fallback. Old-style substring AND.
+    #[arg(long)]
+    no_fuzzy: bool,
 }
 
 #[derive(Debug, Subcommand)]
@@ -728,34 +744,480 @@ fn deactivate_image_record(paths: &AppPaths, image: &ImageRecord) -> Result<()> 
     append_jsonl(&paths.images, &deactivated)
 }
 
+#[derive(Debug, Clone)]
+struct SearchCandidate {
+    path_raw: PathBuf,
+    path_nfc: String,
+    title_nfc: String,
+    description_nfc: String,
+    discovered_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone)]
+struct SearchHit {
+    candidate_idx: usize,
+    score: f64,
+    pattern_score: u32,
+    matched_field: MatchedField,
+    matched_atoms: Vec<String>,
+    source: HitSource,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum HitSource {
+    Fuzzy,
+    Levenshtein,
+    NoFuzzy,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum MatchedField {
+    Title,
+    Description,
+    Path,
+    Multiple,
+}
+
+impl MatchedField {
+    fn as_str(self) -> &'static str {
+        match self {
+            MatchedField::Title => "title",
+            MatchedField::Description => "description",
+            MatchedField::Path => "path",
+            MatchedField::Multiple => "multiple",
+        }
+    }
+}
+
+fn nfc(s: &str) -> String {
+    s.nfc().collect()
+}
+
+fn case_fold_for_search(s: &str, case_sensitive: bool) -> String {
+    if case_sensitive {
+        s.to_string()
+    } else {
+        s.to_lowercase()
+    }
+}
+
+fn smart_case_sensitive(query: &str, case_sensitive: bool) -> bool {
+    case_sensitive || query.chars().any(|ch| ch.is_uppercase())
+}
+
+fn extract_atom_payloads(query: &str) -> Vec<String> {
+    query
+        .split_whitespace()
+        .filter_map(|raw| {
+            let mut atom = raw;
+            if atom.starts_with('!') {
+                return None;
+            }
+            if let Some(stripped) = atom.strip_prefix(r"\!") {
+                atom = stripped;
+            }
+            if let Some(stripped) = atom.strip_prefix('^') {
+                atom = stripped;
+            }
+            if let Some(stripped) = atom.strip_prefix('"') {
+                atom = stripped;
+            }
+            if let Some(stripped) = atom.strip_prefix('\'') {
+                atom = stripped;
+            }
+            if let Some(stripped) = atom.strip_suffix('$') {
+                atom = stripped;
+            }
+            let payload = atom
+                .replace(r"\ ", " ")
+                .replace(r"\^", "^")
+                .replace(r"\'", "'")
+                .replace(r"\$", "$")
+                .replace(r"\!", "!");
+            (!payload.trim().is_empty()).then(|| payload.trim().to_string())
+        })
+        .collect()
+}
+
+fn build_candidates(
+    images: Vec<ImageRecord>,
+    captions: &HashMap<PathBuf, CaptionRecord>,
+) -> Vec<SearchCandidate> {
+    images
+        .into_iter()
+        .map(|image| {
+            let cap = captions.get(&image.path);
+            SearchCandidate {
+                path_nfc: nfc(&image.path.display().to_string()),
+                title_nfc: nfc(cap.map(|c| c.title.as_str()).unwrap_or("<missing>")),
+                description_nfc: nfc(cap.map(|c| c.description.as_str()).unwrap_or("<missing>")),
+                discovered_at: image.discovered_at,
+                path_raw: image.path,
+            }
+        })
+        .collect()
+}
+
+fn score_field(
+    pattern: &Pattern,
+    haystack: &str,
+    weight: f64,
+    matcher: &mut Matcher,
+    buf: &mut Vec<char>,
+) -> Option<(u32, f64)> {
+    pattern
+        .score(Utf32Str::new(haystack, buf), matcher)
+        .map(|score| (score, f64::from(score) * weight))
+}
+
+fn best_matched_field(scores: &[(MatchedField, u32, f64)]) -> MatchedField {
+    if scores.len() > 1 {
+        let best = scores
+            .iter()
+            .map(|(_, _, weighted)| *weighted)
+            .fold(0.0, f64::max);
+        let tied = scores
+            .iter()
+            .filter(|(_, _, weighted)| (*weighted - best).abs() < f64::EPSILON)
+            .count();
+        if tied > 1 {
+            return MatchedField::Multiple;
+        }
+    }
+    scores
+        .iter()
+        .max_by(|a, b| a.2.total_cmp(&b.2))
+        .map(|(field, _, _)| *field)
+        .unwrap_or(MatchedField::Multiple)
+}
+
+fn search_pattern_pass(
+    candidates: &[SearchCandidate],
+    query: &str,
+    matcher: &mut Matcher,
+    case_sensitive: bool,
+) -> Vec<SearchHit> {
+    let case = if case_sensitive {
+        CaseMatching::Respect
+    } else {
+        CaseMatching::Smart
+    };
+    let pattern = Pattern::parse(query, case, Normalization::Smart);
+    let atoms = extract_atom_payloads(query);
+    let smart_sensitive = smart_case_sensitive(query, case_sensitive);
+    let atoms_cmp: Vec<String> = atoms
+        .iter()
+        .map(|atom| case_fold_for_search(atom, smart_sensitive))
+        .collect();
+    let mut buf = Vec::new();
+    let mut hits = Vec::new();
+
+    for (candidate_idx, candidate) in candidates.iter().enumerate() {
+        let mut scores = Vec::new();
+        if let Some((raw, weighted)) =
+            score_field(&pattern, &candidate.title_nfc, 3.0, matcher, &mut buf)
+        {
+            scores.push((MatchedField::Title, raw, weighted));
+        }
+        if let Some((raw, weighted)) =
+            score_field(&pattern, &candidate.description_nfc, 1.5, matcher, &mut buf)
+        {
+            scores.push((MatchedField::Description, raw, weighted));
+        }
+        if let Some((raw, weighted)) =
+            score_field(&pattern, &candidate.path_nfc, 1.0, matcher, &mut buf)
+        {
+            scores.push((MatchedField::Path, raw, weighted));
+        }
+        if scores.is_empty() {
+            continue;
+        }
+
+        let combined_cmp = case_fold_for_search(
+            &format!(
+                "{} {} {}",
+                candidate.title_nfc, candidate.description_nfc, candidate.path_nfc
+            ),
+            smart_sensitive,
+        );
+        if query.split_whitespace().any(|atom| {
+            atom.strip_prefix('!')
+                .filter(|payload| !payload.is_empty())
+                .map(|payload| {
+                    combined_cmp.contains(&case_fold_for_search(payload, smart_sensitive))
+                })
+                .unwrap_or(false)
+        }) {
+            continue;
+        }
+
+        let matched_field = best_matched_field(&scores);
+        let (pattern_score, weighted_score) = scores
+            .iter()
+            .max_by(|a, b| a.2.total_cmp(&b.2))
+            .map(|(_, raw, weighted)| (*raw, *weighted))
+            .unwrap_or((0, 0.0));
+        let title_cmp = case_fold_for_search(&candidate.title_nfc, smart_sensitive);
+        let desc_cmp = case_fold_for_search(&candidate.description_nfc, smart_sensitive);
+        let path_cmp = case_fold_for_search(&candidate.path_nfc, smart_sensitive);
+        let stem_cmp = candidate
+            .path_raw
+            .file_stem()
+            .and_then(OsStr::to_str)
+            .map(nfc)
+            .map(|stem| case_fold_for_search(&stem, smart_sensitive))
+            .unwrap_or_default();
+        let matched_atoms: Vec<String> = atoms
+            .iter()
+            .zip(atoms_cmp.iter())
+            .filter(|(_, atom)| {
+                title_cmp.contains(atom.as_str())
+                    || desc_cmp.contains(atom.as_str())
+                    || path_cmp.contains(atom.as_str())
+            })
+            .map(|(atom, _)| atom.clone())
+            .collect();
+        if !atoms.is_empty() && matched_atoms.is_empty() {
+            continue;
+        }
+        let mut bonus = 0.0;
+        if atoms_cmp
+            .iter()
+            .any(|atom| title_cmp.contains(atom.as_str()))
+        {
+            bonus += 50.0;
+        }
+        if atoms_cmp
+            .first()
+            .is_some_and(|atom| title_cmp.starts_with(atom.as_str()))
+        {
+            bonus += 30.0;
+        }
+        if atoms_cmp
+            .iter()
+            .any(|atom| stem_cmp.contains(atom.as_str()))
+        {
+            bonus += 10.0;
+        }
+
+        hits.push(SearchHit {
+            candidate_idx,
+            score: weighted_score + bonus,
+            pattern_score,
+            matched_field,
+            matched_atoms,
+            source: HitSource::Fuzzy,
+        });
+    }
+
+    hits
+}
+
+fn fallback_threshold(payload: &str) -> Option<f64> {
+    match payload.chars().count() {
+        0..=2 => None,
+        3..=8 => Some(0.75),
+        _ => Some(0.70),
+    }
+}
+
+fn best_window_similarity(atom: &str, text: &str, case_sensitive: bool) -> f64 {
+    let atom_cmp = case_fold_for_search(atom, case_sensitive);
+    let atom_token_count = atom_cmp.split_whitespace().count().max(1);
+    let text_cmp = case_fold_for_search(text, case_sensitive);
+    let tokens: Vec<&str> = text_cmp.split_whitespace().collect();
+    if tokens.is_empty() {
+        return 0.0;
+    }
+    let mut best = 0.0;
+    for size in [
+        atom_token_count.saturating_sub(1),
+        atom_token_count,
+        atom_token_count + 1,
+    ]
+    .into_iter()
+    .filter(|size| *size > 0)
+    {
+        if size > tokens.len() {
+            continue;
+        }
+        for window in tokens.windows(size) {
+            let joined = window.join(" ");
+            let similarity = strsim::normalized_damerau_levenshtein(&atom_cmp, &joined);
+            if similarity > best {
+                best = similarity;
+            }
+        }
+    }
+    best
+}
+
+fn search_levenshtein_fallback(
+    candidates: &[SearchCandidate],
+    query_atoms: &[String],
+    case_sensitive: bool,
+) -> Vec<SearchHit> {
+    let fallback_atoms: Vec<&String> = query_atoms
+        .iter()
+        .filter(|atom| fallback_threshold(atom).is_some())
+        .collect();
+    if fallback_atoms.is_empty() {
+        return Vec::new();
+    }
+
+    let mut hits = Vec::new();
+    for (candidate_idx, candidate) in candidates.iter().enumerate() {
+        let mut similarities = Vec::new();
+        let mut matched_atoms = Vec::new();
+        for atom in &fallback_atoms {
+            let threshold = fallback_threshold(atom).unwrap_or(1.0);
+            let title_similarity =
+                best_window_similarity(atom, &candidate.title_nfc, case_sensitive);
+            let desc_similarity =
+                best_window_similarity(atom, &candidate.description_nfc, case_sensitive);
+            let similarity = title_similarity.max(desc_similarity);
+            if similarity < threshold {
+                similarities.clear();
+                break;
+            }
+            similarities.push(similarity);
+            matched_atoms.push((*atom).clone());
+        }
+        if similarities.len() == fallback_atoms.len() {
+            let avg = similarities.iter().sum::<f64>() / similarities.len() as f64;
+            hits.push(SearchHit {
+                candidate_idx,
+                score: (avg * 1000.0).floor(),
+                pattern_score: 0,
+                matched_field: MatchedField::Multiple,
+                matched_atoms,
+                source: HitSource::Levenshtein,
+            });
+        }
+    }
+    hits
+}
+
+fn print_old_search_result(candidate: &SearchCandidate) {
+    println!(
+        "{}\n  title: {}\n  caption: {}",
+        candidate.path_raw.display(),
+        candidate.title_nfc,
+        candidate.description_nfc
+    );
+}
+
+fn print_text_result(hit: &SearchHit, candidate: &SearchCandidate) {
+    println!(
+        "{}\n  title: {}\n  caption: {}\n  score: {:.1}\n  matches: {} ({})",
+        candidate.path_raw.display(),
+        candidate.title_nfc,
+        candidate.description_nfc,
+        hit.score,
+        hit.matched_field.as_str(),
+        hit.matched_atoms.join(", ")
+    );
+}
+
+fn print_json_result(hit: &SearchHit, candidate: &SearchCandidate) -> Result<()> {
+    println!(
+        "{}",
+        serde_json::to_string(&json!({
+            "path": candidate.path_raw,
+            "title": candidate.title_nfc,
+            "description": candidate.description_nfc,
+            "score": hit.score,
+            "matched_field": hit.matched_field,
+            "matched_atoms": hit.matched_atoms,
+            "source": hit.source,
+        }))?
+    );
+    Ok(())
+}
+
 fn cmd_search(paths: &AppPaths, args: SearchArgs) -> Result<()> {
     if args.keywords.is_empty() {
         bail!("provide at least one keyword");
     }
-    let needle: Vec<String> = args.keywords.iter().map(|k| k.to_lowercase()).collect();
+    let query = nfc(&args.keywords.join(" "));
     let captions = latest_captions_by_path(paths)?;
     let images = latest_images(paths)?;
-    let mut printed = 0;
-    for image in images {
-        let cap = captions.get(&image.path);
-        let haystack = format!(
-            "{} {} {}",
-            image.path.display(),
-            cap.map(|c| c.title.as_str()).unwrap_or_default(),
-            cap.map(|c| c.description.as_str()).unwrap_or_default()
-        )
-        .to_lowercase();
-        if needle.iter().all(|keyword| haystack.contains(keyword)) {
-            println!(
-                "{}\n  title: {}\n  caption: {}",
-                image.path.display(),
-                cap.map(|c| c.title.as_str()).unwrap_or("<missing>"),
-                cap.map(|c| c.description.as_str()).unwrap_or("<missing>")
-            );
+    let candidates = build_candidates(images, &captions);
+
+    if args.no_fuzzy {
+        let needle: Vec<String> = args.keywords.iter().map(|k| k.to_lowercase()).collect();
+        let mut printed = 0;
+        for candidate in &candidates {
+            let haystack = format!(
+                "{} {} {}",
+                candidate.path_raw.display(),
+                candidate.title_nfc,
+                candidate.description_nfc
+            )
+            .to_lowercase();
+            if !needle.iter().all(|keyword| haystack.contains(keyword)) {
+                continue;
+            }
+            let hit = SearchHit {
+                candidate_idx: 0,
+                score: 0.0,
+                pattern_score: 0,
+                matched_field: MatchedField::Multiple,
+                matched_atoms: Vec::new(),
+                source: HitSource::NoFuzzy,
+            };
+            let _ = hit;
+            print_old_search_result(candidate);
             printed += 1;
             if printed >= args.limit {
                 break;
             }
+        }
+        return Ok(());
+    }
+
+    let mut matcher = Matcher::new(Config::DEFAULT);
+    let mut hits = search_pattern_pass(&candidates, &query, &mut matcher, args.case_sensitive);
+    let query_atoms = extract_atom_payloads(&query);
+    let mut used_fallback = false;
+    if hits.is_empty()
+        && !query_atoms.is_empty()
+        && !smart_case_sensitive(&query, args.case_sensitive)
+        && query_atoms
+            .iter()
+            .any(|atom| fallback_threshold(atom).is_some())
+    {
+        hits = search_levenshtein_fallback(&candidates, &query_atoms, args.case_sensitive);
+        used_fallback = !hits.is_empty();
+    }
+
+    hits.sort_by(|a, b| {
+        b.score
+            .total_cmp(&a.score)
+            .then_with(|| b.pattern_score.cmp(&a.pattern_score))
+            .then_with(|| {
+                candidates[b.candidate_idx]
+                    .discovered_at
+                    .cmp(&candidates[a.candidate_idx].discovered_at)
+            })
+            .then_with(|| {
+                candidates[a.candidate_idx]
+                    .path_raw
+                    .cmp(&candidates[b.candidate_idx].path_raw)
+            })
+    });
+
+    if used_fallback && !args.json {
+        println!("(no fuzzy matches; falling back to typo-tolerant search)");
+    }
+    for hit in hits.iter().take(args.limit) {
+        let candidate = &candidates[hit.candidate_idx];
+        if args.json {
+            print_json_result(hit, candidate)?;
+        } else {
+            print_text_result(hit, candidate);
         }
     }
     Ok(())

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -222,6 +222,325 @@ fn read_jsonl(path: &Path) -> Vec<serde_json::Value> {
         .collect()
 }
 
+fn setup_search_fixture(
+    entries: &[(&str, &str, &str, &str, bool)],
+) -> (tempfile::TempDir, PathBuf) {
+    let temp = tempfile::tempdir().unwrap();
+    let config = temp.path().join("state");
+    let images = temp.path().join("images");
+    fs::create_dir_all(&images).unwrap();
+    assert_success(run(&config, &["init"]));
+
+    let mut image_lines = String::new();
+    let mut caption_lines = String::new();
+    for (idx, (name, title, description, discovered_at, active)) in entries.iter().enumerate() {
+        let path = images.join(name);
+        fs::write(&path, b"not really png").unwrap();
+        let canonical = path.canonicalize().unwrap();
+        let id = format!("image-{idx}");
+        let image = serde_json::json!({
+            "id": id,
+            "path": canonical,
+            "original_path": canonical,
+            "sha256": format!("sha{idx}"),
+            "size": 1,
+            "modified_at": null,
+            "discovered_at": discovered_at,
+            "extension": "png",
+            "active": active,
+            "removed_at": null,
+        });
+        image_lines.push_str(&format!("{image}\n"));
+        let caption = serde_json::json!({
+            "image_id": id,
+            "path": canonical,
+            "title": title,
+            "description": description,
+            "model": "test",
+            "provider": "test",
+            "created_at": "2026-05-04T00:00:00Z",
+            "filename_meaningful": false
+        });
+        caption_lines.push_str(&format!("{caption}\n"));
+    }
+    fs::write(config.join("images.jsonl"), image_lines).unwrap();
+    fs::write(config.join("captions.jsonl"), caption_lines).unwrap();
+    (temp, config)
+}
+
+fn result_paths(stdout: &str) -> Vec<&str> {
+    stdout
+        .lines()
+        .filter(|line| line.ends_with(".png"))
+        .collect()
+}
+
+#[test]
+fn search_ranks_title_above_description() {
+    let (_temp, config) = setup_search_fixture(&[
+        (
+            "desc.png",
+            "Settings Panel",
+            "Login workflow appears in a browser",
+            "2026-05-04T00:00:00Z",
+            true,
+        ),
+        (
+            "title.png",
+            "Login Dialog",
+            "A generic modal",
+            "2026-05-03T00:00:00Z",
+            true,
+        ),
+    ]);
+    let stdout = assert_success(run(&config, &["search", "login"]));
+    let paths = result_paths(&stdout);
+    assert!(paths[0].ends_with("title.png"), "got: {stdout}");
+}
+
+#[test]
+fn search_smart_case_lowercase_query() {
+    let (_temp, config) = setup_search_fixture(&[(
+        "mixed.png",
+        "Login Dialog",
+        "Mixed case title",
+        "2026-05-04T00:00:00Z",
+        true,
+    )]);
+    let stdout = assert_success(run(&config, &["search", "login"]));
+    assert!(stdout.contains("mixed.png"));
+}
+
+#[test]
+fn search_smart_case_uppercase_query_is_case_sensitive() {
+    let (_temp, config) = setup_search_fixture(&[(
+        "lower.png",
+        "login dialog",
+        "lowercase title",
+        "2026-05-04T00:00:00Z",
+        true,
+    )]);
+    let stdout = assert_success(run(&config, &["search", "Login"]));
+    assert!(stdout.trim().is_empty(), "got: {stdout}");
+}
+
+#[test]
+fn search_fzf_dsl_negation() {
+    let (_temp, config) = setup_search_fixture(&[
+        (
+            "good.png",
+            "Login dialog",
+            "production UI",
+            "2026-05-04T00:00:00Z",
+            true,
+        ),
+        (
+            "bad.png",
+            "Login dialog",
+            "test fixture UI",
+            "2026-05-05T00:00:00Z",
+            true,
+        ),
+    ]);
+    let stdout = assert_success(run(&config, &["search", "login", "!test"]));
+    assert!(stdout.contains("good.png"));
+    assert!(!stdout.contains("bad.png"));
+}
+
+#[test]
+fn search_fzf_dsl_exact() {
+    let (_temp, config) = setup_search_fixture(&[
+        ("foo.png", "foo", "exact", "2026-05-04T00:00:00Z", true),
+        ("fo.png", "fo", "short", "2026-05-05T00:00:00Z", true),
+    ]);
+    let stdout = assert_success(run(&config, &["search", "'foo"]));
+    assert!(stdout.contains("foo.png"));
+    assert!(!stdout.contains("fo.png"));
+}
+
+#[test]
+fn search_fzf_dsl_prefix() {
+    let (_temp, config) = setup_search_fixture(&[
+        (
+            "login.png",
+            "login panel",
+            "prefix",
+            "2026-05-04T00:00:00Z",
+            true,
+        ),
+        (
+            "other.png",
+            "panel login",
+            "not prefix",
+            "2026-05-05T00:00:00Z",
+            true,
+        ),
+    ]);
+    let stdout = assert_success(run(&config, &["search", "^login"]));
+    assert!(stdout.contains("login.png"));
+    assert!(!stdout.contains("other.png"));
+}
+
+#[test]
+fn search_levenshtein_fallback_typo() {
+    let (_temp, config) = setup_search_fixture(&[(
+        "screen.png",
+        "Screenshot capture",
+        "desktop image",
+        "2026-05-04T00:00:00Z",
+        true,
+    )]);
+    let stdout = assert_success(run(&config, &["search", "scrnshot"]));
+    assert!(stdout.contains("falling back"), "got: {stdout}");
+    assert!(stdout.contains("screen.png"));
+}
+
+#[test]
+fn search_levenshtein_skipped_for_short_atom() {
+    let (_temp, config) = setup_search_fixture(&[(
+        "ux.png",
+        "UX panel",
+        "interface settings",
+        "2026-05-04T00:00:00Z",
+        true,
+    )]);
+    let stdout = assert_success(run(&config, &["search", "ui"]));
+    assert!(stdout.trim().is_empty(), "got: {stdout}");
+}
+
+#[test]
+fn search_no_fuzzy_disables_dsl_and_fallback() {
+    let (_temp, config) = setup_search_fixture(&[(
+        "bang.png",
+        "literal !foo marker",
+        "not a negation",
+        "2026-05-04T00:00:00Z",
+        true,
+    )]);
+    let stdout = assert_success(run(&config, &["search", "!foo", "--no-fuzzy"]));
+    assert!(stdout.contains("bang.png"));
+    assert!(!stdout.contains("score:"), "old output only: {stdout}");
+}
+
+#[test]
+fn search_json_output_jsonl_one_per_line() {
+    let (_temp, config) = setup_search_fixture(&[(
+        "json.png",
+        "Login JSON",
+        "structured output",
+        "2026-05-04T00:00:00Z",
+        true,
+    )]);
+    let stdout = assert_success(run(&config, &["search", "login", "--json"]));
+    for line in stdout.lines().filter(|line| !line.trim().is_empty()) {
+        let value: serde_json::Value = serde_json::from_str(line).unwrap();
+        assert_eq!(value["source"], "fuzzy");
+        assert!(value["score"].is_number());
+    }
+}
+
+#[test]
+fn search_case_sensitive_flag() {
+    let (_temp, config) = setup_search_fixture(&[(
+        "case.png",
+        "foo panel",
+        "lowercase only",
+        "2026-05-04T00:00:00Z",
+        true,
+    )]);
+    let stdout = assert_success(run(&config, &["search", "Foo", "--case-sensitive"]));
+    assert!(stdout.trim().is_empty(), "got: {stdout}");
+}
+
+#[test]
+fn search_korean_nfc_normalization() {
+    let nfd = "한글";
+    let (_temp, config) = setup_search_fixture(&[(
+        "korean.png",
+        nfd,
+        "decomposed Hangul caption",
+        "2026-05-04T00:00:00Z",
+        true,
+    )]);
+    let stdout = assert_success(run(&config, &["search", "한글"]));
+    assert!(stdout.contains("korean.png"), "got: {stdout}");
+}
+
+#[test]
+fn search_active_false_excluded() {
+    let (_temp, config) = setup_search_fixture(&[
+        (
+            "active.png",
+            "Login active",
+            "kept",
+            "2026-05-04T00:00:00Z",
+            true,
+        ),
+        (
+            "inactive.png",
+            "Login inactive",
+            "pruned",
+            "2026-05-05T00:00:00Z",
+            false,
+        ),
+    ]);
+    let stdout = assert_success(run(&config, &["search", "login"]));
+    assert!(stdout.contains("active.png"));
+    assert!(!stdout.contains("inactive.png"));
+}
+
+#[test]
+fn search_no_results_clean_exit() {
+    let (_temp, config) =
+        setup_search_fixture(&[("one.png", "Settings", "panel", "2026-05-04T00:00:00Z", true)]);
+    let stdout = assert_success(run(&config, &["search", "nomatch"]));
+    assert!(stdout.trim().is_empty(), "got: {stdout}");
+}
+
+#[test]
+fn search_limit_truncates_after_sort() {
+    let (_temp, config) = setup_search_fixture(&[
+        (
+            "path-login.png",
+            "Other",
+            "misc",
+            "2026-05-05T00:00:00Z",
+            true,
+        ),
+        (
+            "desc.png",
+            "Other",
+            "login description",
+            "2026-05-04T00:00:00Z",
+            true,
+        ),
+        (
+            "title-a.png",
+            "Login Alpha",
+            "best",
+            "2026-05-03T00:00:00Z",
+            true,
+        ),
+        (
+            "title-b.png",
+            "Login Beta",
+            "best",
+            "2026-05-06T00:00:00Z",
+            true,
+        ),
+        ("other.png", "Login", "best", "2026-05-02T00:00:00Z", true),
+    ]);
+    let stdout = assert_success(run(&config, &["search", "login", "--limit", "2"]));
+    let paths = result_paths(&stdout);
+    assert_eq!(paths.len(), 2, "got: {stdout}");
+    assert!(
+        paths
+            .iter()
+            .all(|path| path.contains("title") || path.contains("other")),
+        "got: {stdout}"
+    );
+}
+
 #[test]
 fn bootstrap_prune_marks_missing_files_inactive() {
     let temp = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

- Replace naive lowercased substring AND-match in `cmd_search` with a ranked, ad-hoc search using `nucleo-matcher` for fzf-style fuzzy ranking + a tiny query DSL, plus a `strsim` token/window Levenshtein fallback for typos.
- Add `--json`, `--case-sensitive`, and `--no-fuzzy` flags; NFC-normalize query and haystacks for correct Korean/Unicode matching on macOS.
- 15 new CLI integration tests; `make ci` green.

## Why

Search was substring-only, unranked, and `--limit` truncated arbitrary first matches. \"login error\" vs \"auth failure\" stays out of scope (no semantic search by design — see Non-Goals), but the overhaul fixes ranking, typo tolerance, field weighting, and adds a stable JSON output for agents — all without introducing an index or embeddings.

## Design (Oracle-reviewed, Momus-approved)

Plan: `.sisyphus/plans/search-overhaul.md` (local; not in PR).

Key decisions:
- **DSL** delegated to `nucleo_matcher::pattern::Pattern::parse` — no custom parser. Supports `'foo` (exact), `^foo` (prefix), `foo$` (suffix), `!foo` (negate), whitespace-AND, `\\ ` escape.
- **Field weighting**: `max(title*3.0, desc*1.5, path*1.0)` per candidate (Oracle-recommended over additive sum, which Oracle flagged would let mediocre cross-field matches beat strong title hits).
- **Bonuses**: title-exact (+50), title-prefix (+30), filename-stem (+10).
- **Levenshtein fallback** is token/window, not whole-field, with thresholds by payload length (≤2 chars: skipped; 3-8: ≥0.75; >8: ≥0.70). Skipped for negation-only queries and under `--no-fuzzy`.
- **NFC normalization** applied once per invocation to query + each haystack field. macOS HFS+ stores NFD; Korean IMEs produce NFC; without normalization \"한글\" wouldn't match itself across stores.
- **Smart-case** follows ripgrep (lowercase query → case-insensitive; any uppercase → case-sensitive); `--case-sensitive` overrides.
- **`--no-fuzzy`** preserves OLD behavior + OLD 3-line output exactly (substring AND, no DSL, no fallback) as a stable scripting escape hatch.
- **Tie-breaking**: score desc → pre-bonus score desc → discovered_at desc → path asc.

## Output formats

**Default text** (new, sorted by score desc):
\`\`\`
/path/to/foo.png
  title: Login failure modal
  caption: Auth error after expired session
  score: 1842.0
  matches: title (login, error)
\`\`\`

**JSONL** (`--json`, stable for agents):
\`\`\`json
{\"path\":\"...\",\"title\":\"...\",\"description\":\"...\",\"score\":1842.0,\"matched_field\":\"title\",\"matched_atoms\":[\"login\",\"error\"],\"source\":\"fuzzy\"}
\`\`\`

**`--no-fuzzy`** emits the OLD 3-line format unchanged.

## Test plan

- 15 new tests in `tests/cli.rs`: ranking, smart-case (lower + upper), DSL ops (negation/exact/prefix), fallback typo, short-atom fallback skip, `--no-fuzzy`, `--json`, `--case-sensitive`, Korean NFC/NFD, active=false exclusion, limit, no-results clean exit.
- 34 CLI integration tests + 30 unit tests pass. Existing `folder_bootstrap_search_and_remove_flow` still green (regression).
- `make ci`: fmt + clippy (zero warnings) + test + build all exit 0.

## Manual QA

8 scenarios captured against a fresh state dir (login-ranked, github actions multi-token, !test exclusion, scrnshot typo→fallback header, `--json` JSONL, `--no-fuzzy` old format, short \"ui\" no-results, NFC \"한글\" matching NFD-stored caption).

Spot-check sample (NFD-stored \"한글 문서\" matched by NFC \"한글\"): score 266.0, exit 0.

## Breaking changes

- Default text output now contains additional `score:` and `matches:` lines and is sorted by relevance instead of iteration order. Brittle scripts that parsed exactly 3 lines per result must migrate to `--json` (recommended) or use `--no-fuzzy` for the OLD format.
- Documented in README's Search section.

## Dependencies

- `nucleo-matcher = \"0.3\"` (Helix-maintained, fzf v2 algorithm)
- `strsim = \"0.11\"` (rapidfuzz-maintained)
- `unicode-normalization = \"0.1\"` (NFC for Korean/Unicode robustness)

No transitive concerns; all three are widely used and active.

## Out of scope

- No semantic synonym map (\"login\" ↔ \"auth\"). Documented as a non-goal.
- No OCR text extraction.
- No persistent index.