### PR TITLE
fix: make bootstrap truly incremental

### DIFF
--- a/crates/clawgallery-vdr/src/lib.rs
+++ b/crates/clawgallery-vdr/src/lib.rs
@@ -151,9 +151,11 @@ pub fn sync(
         }
         indexed_vectors += response.embeddings.len();
         for (item, vector) in batch.iter().zip(response.embeddings) {
-            store::deactivate_stale_vectors(&conn, &item.image_id, &item.sha256)?;
-            store::deactivate_existing_kind(&conn, &item.image_id, item.kind)?;
-            store::insert_vector(&conn, item, &response.model, config.dimensions, &vector)?;
+            let tx = conn.unchecked_transaction()?;
+            store::deactivate_stale_vectors(&tx, &item.image_id, &item.sha256)?;
+            store::deactivate_existing_kind(&tx, &item.image_id, item.kind)?;
+            store::insert_vector(&tx, item, &response.model, config.dimensions, &vector)?;
+            tx.commit()?;
         }
     }
     Ok(SyncOutcome { indexed_vectors })

--- a/crates/clawgallery-vdr/src/lib.rs
+++ b/crates/clawgallery-vdr/src/lib.rs
@@ -151,6 +151,7 @@ pub fn sync(
         }
         indexed_vectors += response.embeddings.len();
         for (item, vector) in batch.iter().zip(response.embeddings) {
+            store::deactivate_stale_vectors(&conn, &item.image_id, &item.sha256)?;
             store::deactivate_existing_kind(&conn, &item.image_id, item.kind)?;
             store::insert_vector(&conn, item, &response.model, config.dimensions, &vector)?;
         }

--- a/crates/clawgallery-vdr/src/store.rs
+++ b/crates/clawgallery-vdr/src/store.rs
@@ -131,6 +131,19 @@ pub(super) fn prune_inactive_vectors(
     Ok(())
 }
 
+pub(super) fn deactivate_stale_vectors(
+    conn: &Connection,
+    image_id: &str,
+    sha256: &str,
+) -> Result<()> {
+    conn.execute(
+        "update vdr_embeddings set active = 0
+         where image_id = ?1 and sha256 <> ?2 and active = 1",
+        params![image_id, sha256],
+    )?;
+    Ok(())
+}
+
 pub(super) fn insert_vector(
     conn: &Connection,
     item: &PendingEmbedding,

--- a/src/main.rs
+++ b/src/main.rs
@@ -564,7 +564,19 @@ fn cmd_bootstrap(paths: &AppPaths, args: &IngestArgs) -> Result<BootstrapStats> 
         seen_paths.insert(canonical.clone());
         match refresh_image_record(&canonical, existing.get(&canonical)) {
             Ok(ImageRefresh::Unchanged) => {}
-            Ok(ImageRefresh::MetadataOnly(record) | ImageRefresh::New(record)) => {
+            Ok(ImageRefresh::MetadataOnly(record)) => {
+                append_jsonl(&paths.images, &record)?;
+                ingested += 1;
+            }
+            Ok(ImageRefresh::New(record)) => {
+                if let Some(caption) = captions.get(&canonical)
+                    && caption.source_sha256.as_deref() == Some(record.sha256.as_str())
+                    && caption.image_id != record.id
+                {
+                    let mut normalized = caption.clone();
+                    normalized.image_id.clone_from(&record.id);
+                    append_jsonl(&paths.captions, &normalized)?;
+                }
                 append_jsonl(&paths.images, &record)?;
                 ingested += 1;
             }
@@ -698,10 +710,19 @@ fn cmd_caption(paths: &AppPaths, args: CaptionArgs) -> Result<()> {
     let mut images = latest_images(paths)?;
     if let Some(file) = args.file {
         let canonical = fs::canonicalize(&file).unwrap_or(file);
-        if !images.iter().any(|image| image.path == canonical) {
-            images.push(build_image_record(&canonical)?);
-        }
-        images.retain(|image| image.path == canonical);
+        let previous = images.iter().find(|image| image.path == canonical).cloned();
+        let record = match refresh_image_record(&canonical, previous.as_ref())? {
+            ImageRefresh::Unchanged => previous
+                .ok_or_else(|| anyhow!("unchanged image refresh requires an existing record"))?,
+            ImageRefresh::MetadataOnly(record) | ImageRefresh::ContentChanged(record) => {
+                if !args.dry_run {
+                    append_jsonl(&paths.images, &record)?;
+                }
+                record
+            }
+            ImageRefresh::New(record) => record,
+        };
+        images = vec![record];
     }
     if args.missing {
         let captioned: HashSet<String> = latest_captions(paths)?

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,11 +26,12 @@ use walkdir::WalkDir;
 mod state;
 mod vdr;
 
+use state::ImageRefresh;
 pub(crate) use state::{
-    AppConfig, AppPaths, CaptionRecord, FolderRecord, ImageRecord, active_folders, append_jsonl,
-    build_image_record, is_image_path, latest_captions, latest_captions_by_path, latest_images,
-    latest_images_by_path, latest_images_refreshing_changed_files, read_config, read_jsonl,
-    write_json_pretty,
+    AppConfig, AppPaths, CaptionRecord, FolderRecord, ImageRecord, active_folders,
+    all_latest_captions_by_path, append_jsonl, build_image_record, is_image_path, latest_captions,
+    latest_captions_by_path, latest_images, latest_images_by_path, read_config, read_jsonl,
+    refresh_image_record, write_json_pretty,
 };
 
 const APP_DIR_NAME: &str = "clawgallery";
@@ -552,6 +553,7 @@ struct BootstrapStats {
 fn cmd_bootstrap(paths: &AppPaths, args: &IngestArgs) -> Result<BootstrapStats> {
     ensure_state_files(paths)?;
     let existing = latest_images_by_path(paths)?;
+    let captions = all_latest_captions_by_path(paths)?;
     let mut seen_paths: HashSet<PathBuf> = HashSet::new();
     let mut ingested = 0;
     for image_path in candidate_image_paths(paths, args)? {
@@ -560,12 +562,20 @@ fn cmd_bootstrap(paths: &AppPaths, args: &IngestArgs) -> Result<BootstrapStats> 
             continue;
         }
         seen_paths.insert(canonical.clone());
-        match build_image_record(&canonical) {
-            Ok(record) => {
-                if let Some(previous) = existing.get(&canonical)
-                    && previous.has_same_file_fingerprint(&record)
+        match refresh_image_record(&canonical, existing.get(&canonical)) {
+            Ok(ImageRefresh::Unchanged) => {}
+            Ok(ImageRefresh::MetadataOnly(record) | ImageRefresh::New(record)) => {
+                append_jsonl(&paths.images, &record)?;
+                ingested += 1;
+            }
+            Ok(ImageRefresh::ContentChanged(record)) => {
+                if let Some(caption) = captions.get(&canonical)
+                    && caption.source_sha256.is_none()
+                    && let Some(previous) = existing.get(&canonical)
                 {
-                    continue;
+                    let mut fingerprinted = caption.clone();
+                    fingerprinted.source_sha256 = Some(previous.sha256.clone());
+                    append_jsonl(&paths.captions, &fingerprinted)?;
                 }
                 append_jsonl(&paths.images, &record)?;
                 ingested += 1;
@@ -722,6 +732,7 @@ fn cmd_caption(paths: &AppPaths, args: CaptionArgs) -> Result<()> {
                 let record = CaptionRecord {
                     image_id: result.image.id.clone(),
                     path: result.image.path.clone(),
+                    source_sha256: Some(result.image.sha256.clone()),
                     title: output.title,
                     description: output.description,
                     model: effective_model.clone(),

--- a/src/state.rs
+++ b/src/state.rs
@@ -229,13 +229,17 @@ pub(crate) fn latest_captions_by_path(paths: &AppPaths) -> Result<HashMap<PathBu
     let images = latest_images_by_path(paths)?;
     Ok(all_latest_captions_by_path(paths)?
         .into_iter()
-        .filter(|(path, caption)| {
-            images.get(path).is_some_and(|image| {
-                caption.source_sha256.as_deref().map_or_else(
-                    || caption.image_id == image.id,
-                    |sha256| sha256 == image.sha256,
-                )
-            })
+        .filter_map(|(path, mut caption)| {
+            let image = images.get(&path)?;
+            let is_current = caption.source_sha256.as_deref().map_or_else(
+                || caption.image_id == image.id,
+                |sha256| sha256 == image.sha256,
+            );
+            if !is_current {
+                return None;
+            }
+            caption.image_id.clone_from(&image.id);
+            Some((path, caption))
         })
         .collect())
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -231,11 +231,10 @@ pub(crate) fn latest_captions_by_path(paths: &AppPaths) -> Result<HashMap<PathBu
         .into_iter()
         .filter(|(path, caption)| {
             images.get(path).is_some_and(|image| {
-                caption.image_id == image.id
-                    && caption
-                        .source_sha256
-                        .as_deref()
-                        .is_none_or(|sha256| sha256 == image.sha256)
+                caption.source_sha256.as_deref().map_or_else(
+                    || caption.image_id == image.id,
+                    |sha256| sha256 == image.sha256,
+                )
             })
         })
         .collect())

--- a/src/state.rs
+++ b/src/state.rs
@@ -7,7 +7,7 @@ use std::{
     env,
     ffi::OsStr,
     fs::{self, File, OpenOptions},
-    io::{BufRead, BufReader, Write},
+    io::{BufRead, BufReader, Read, Write},
     path::{Path, PathBuf},
 };
 use uuid::Uuid;
@@ -117,18 +117,19 @@ fn default_active() -> bool {
     true
 }
 
-impl ImageRecord {
-    pub(crate) fn has_same_file_fingerprint(&self, other: &Self) -> bool {
-        self.sha256 == other.sha256
-            && self.size == other.size
-            && self.modified_at == other.modified_at
-    }
+pub(crate) enum ImageRefresh {
+    Unchanged,
+    MetadataOnly(ImageRecord),
+    ContentChanged(ImageRecord),
+    New(ImageRecord),
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub(crate) struct CaptionRecord {
     pub(crate) image_id: String,
     pub(crate) path: PathBuf,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) source_sha256: Option<String>,
     pub(crate) title: String,
     pub(crate) description: String,
     pub(crate) model: String,
@@ -212,26 +213,6 @@ pub(crate) fn latest_images_by_path(paths: &AppPaths) -> Result<HashMap<PathBuf,
         .collect())
 }
 
-pub(crate) fn latest_images_refreshing_changed_files(
-    paths: &AppPaths,
-) -> Result<(Vec<ImageRecord>, bool)> {
-    let mut images = latest_images(paths)?;
-    let mut refreshed = false;
-    for image in &mut images {
-        if !image.path.exists() {
-            continue;
-        }
-        let current = build_image_record(&image.path)?;
-        if image.has_same_file_fingerprint(&current) {
-            continue;
-        }
-        append_jsonl(&paths.images, &current)?;
-        *image = current;
-        refreshed = true;
-    }
-    Ok((images, refreshed))
-}
-
 fn all_latest_images_by_path(paths: &AppPaths) -> Result<HashMap<PathBuf, ImageRecord>> {
     let mut images = HashMap::new();
     for image in read_jsonl::<ImageRecord>(&paths.images)? {
@@ -245,6 +226,24 @@ pub(crate) fn latest_captions(paths: &AppPaths) -> Result<Vec<CaptionRecord>> {
 }
 
 pub(crate) fn latest_captions_by_path(paths: &AppPaths) -> Result<HashMap<PathBuf, CaptionRecord>> {
+    let images = latest_images_by_path(paths)?;
+    Ok(all_latest_captions_by_path(paths)?
+        .into_iter()
+        .filter(|(path, caption)| {
+            images.get(path).is_some_and(|image| {
+                caption.image_id == image.id
+                    && caption
+                        .source_sha256
+                        .as_deref()
+                        .is_none_or(|sha256| sha256 == image.sha256)
+            })
+        })
+        .collect())
+}
+
+pub(crate) fn all_latest_captions_by_path(
+    paths: &AppPaths,
+) -> Result<HashMap<PathBuf, CaptionRecord>> {
     let mut captions = HashMap::new();
     for caption in read_jsonl::<CaptionRecord>(&paths.captions)? {
         captions.insert(caption.path.clone(), caption);
@@ -253,32 +252,85 @@ pub(crate) fn latest_captions_by_path(paths: &AppPaths) -> Result<HashMap<PathBu
 }
 
 pub(crate) fn build_image_record(path: &Path) -> Result<ImageRecord> {
+    match refresh_image_record(path, None)? {
+        ImageRefresh::New(record) => Ok(record),
+        ImageRefresh::Unchanged
+        | ImageRefresh::MetadataOnly(_)
+        | ImageRefresh::ContentChanged(_) => Err(anyhow!(
+            "new image unexpectedly resolved as an existing record"
+        )),
+    }
+}
+
+pub(crate) fn refresh_image_record(
+    path: &Path,
+    previous: Option<&ImageRecord>,
+) -> Result<ImageRefresh> {
     let metadata =
         fs::metadata(path).with_context(|| format!("metadata failed for {}", path.display()))?;
     let modified_at = metadata.modified().ok().map(DateTime::<Utc>::from);
+    if previous.is_some_and(|image| {
+        image.size == metadata.len() && image.modified_at == modified_at && image.active
+    }) {
+        return Ok(ImageRefresh::Unchanged);
+    }
+    let sha256 = sha256_file(path)?;
     let extension = path
         .extension()
         .and_then(OsStr::to_str)
         .unwrap_or_default()
         .to_lowercase();
-    Ok(ImageRecord {
-        id: Uuid::new_v4().to_string(),
+    let Some(previous) = previous else {
+        return Ok(ImageRefresh::New(ImageRecord {
+            id: Uuid::new_v4().to_string(),
+            path: path.to_path_buf(),
+            original_path: path.to_path_buf(),
+            sha256,
+            size: metadata.len(),
+            modified_at,
+            discovered_at: Utc::now(),
+            extension,
+            active: true,
+            removed_at: None,
+        }));
+    };
+    let content_changed = previous.sha256 != sha256;
+    let record = ImageRecord {
+        id: previous.id.clone(),
         path: path.to_path_buf(),
-        original_path: path.to_path_buf(),
-        sha256: sha256_file(path)?,
+        original_path: previous.original_path.clone(),
+        sha256,
         size: metadata.len(),
         modified_at,
-        discovered_at: Utc::now(),
+        discovered_at: previous.discovered_at,
         extension,
         active: true,
         removed_at: None,
-    })
+    };
+    if content_changed {
+        Ok(ImageRefresh::ContentChanged(record))
+    } else {
+        Ok(ImageRefresh::MetadataOnly(record))
+    }
 }
 
 fn sha256_file(path: &Path) -> Result<String> {
-    let bytes = fs::read(path).with_context(|| format!("failed to read {}", path.display()))?;
-    let digest = Sha256::digest(bytes);
-    Ok(format!("{digest:x}"))
+    let file = File::open(path).with_context(|| format!("failed to read {}", path.display()))?;
+    sha256_reader(BufReader::new(file))
+        .with_context(|| format!("failed to read {}", path.display()))
+}
+
+fn sha256_reader(mut reader: impl Read) -> Result<String> {
+    let mut digest = Sha256::new();
+    let mut buffer = [0_u8; 8 * 1024];
+    loop {
+        let read = reader.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        digest.update(&buffer[..read]);
+    }
+    Ok(format!("{:x}", digest.finalize()))
 }
 
 pub(crate) fn is_image_path(path: &Path) -> bool {
@@ -286,4 +338,42 @@ pub(crate) fn is_image_path(path: &Path) -> bool {
         .and_then(OsStr::to_str)
         .map(|ext| IMAGE_EXTENSIONS.contains(&ext.to_lowercase().as_str()))
         .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Cursor, Read};
+
+    struct BoundedRead<R> {
+        inner: R,
+        max_buffer: usize,
+    }
+
+    impl<R: Read> Read for BoundedRead<R> {
+        fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+            assert!(
+                buffer.len() <= self.max_buffer,
+                "hashing requested a {} byte buffer",
+                buffer.len()
+            );
+            self.inner.read(buffer)
+        }
+    }
+
+    #[test]
+    fn sha256_reader_hashes_input_in_bounded_chunks() {
+        // Given: input larger than the maximum read buffer accepted by the source.
+        let bytes = vec![0x5a; 32 * 1024];
+        let reader = BoundedRead {
+            inner: Cursor::new(&bytes),
+            max_buffer: 8 * 1024,
+        };
+
+        // When: the streaming hash helper consumes it.
+        let digest = sha256_reader(reader).expect("streaming hash");
+
+        // Then: the digest is complete without requesting a whole-file buffer.
+        assert_eq!(digest, format!("{:x}", Sha256::digest(&bytes)));
+    }
 }

--- a/src/vdr/mod.rs
+++ b/src/vdr/mod.rs
@@ -127,14 +127,14 @@ fn cmd_serve(args: VdrServeArgs) -> Result<()> {
 pub(crate) fn cmd_sync(paths: &AppPaths, args: VdrSyncArgs) -> Result<()> {
     let backend = resolve_backend(args.backend, args.model.as_deref(), args.dimensions)?;
     let captions = crate::latest_captions_by_path(paths)?;
-    let (images, refreshed_files) = crate::latest_images_refreshing_changed_files(paths)?;
+    let images = crate::latest_images(paths)?;
     let config = SyncConfig {
         db_path: paths.vdr_db.clone(),
         model: backend.model.clone(),
         dimensions: backend.dimensions,
         embedding_url: args.embedding_url.clone(),
         max_retries: args.max_retries,
-        prune: args.prune || refreshed_files,
+        prune: args.prune,
     };
     let image_documents = image_documents(&images);
     let caption_documents = caption_documents_from_map(captions);

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2,7 +2,11 @@ use std::{
     env, fs,
     path::{Path, PathBuf},
     process::{Command, Output},
+    time::{Duration, SystemTime},
 };
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 
 fn bin() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_clawgallery"))
@@ -71,6 +75,144 @@ fn folder_bootstrap_search_and_remove_flow() {
     ));
     let listed_after = assert_success(run(&config, &["folder", "list"]));
     assert!(listed_after.trim().is_empty());
+}
+
+#[cfg(unix)]
+#[test]
+fn bootstrap_unchanged_metadata_does_not_read_image_again() {
+    // Given: an indexed image whose bytes can no longer be opened.
+    let temp = tempfile::tempdir().unwrap();
+    let config = temp.path().join("state");
+    let image = temp.path().join("screen.png");
+    fs::write(&image, b"unchanged image bytes").unwrap();
+    assert_success(run(&config, &["init"]));
+    assert_success(run(
+        &config,
+        &["bootstrap", "--path", image.to_str().unwrap()],
+    ));
+    let images_before = fs::read(config.join("images.jsonl")).unwrap();
+    fs::set_permissions(&image, fs::Permissions::from_mode(0o000)).unwrap();
+
+    // When: bootstrap sees the same size and modified time.
+    let output = run(&config, &["bootstrap", "--path", image.to_str().unwrap()]);
+    fs::set_permissions(&image, fs::Permissions::from_mode(0o600)).unwrap();
+    assert_success(output);
+
+    // Then: it neither reads the image nor appends an error or image record.
+    assert_eq!(
+        fs::read(config.join("images.jsonl")).unwrap(),
+        images_before
+    );
+    assert_eq!(fs::read_to_string(config.join("errors.jsonl")).unwrap(), "");
+}
+
+#[test]
+fn bootstrap_metadata_only_change_preserves_image_id() {
+    // Given: one indexed image and its original fingerprint.
+    let temp = tempfile::tempdir().unwrap();
+    let config = temp.path().join("state");
+    let image = temp.path().join("screen.png");
+    fs::write(&image, b"same image bytes").unwrap();
+    assert_success(run(&config, &["init"]));
+    assert_success(run(
+        &config,
+        &["bootstrap", "--path", image.to_str().unwrap()],
+    ));
+    let before = read_jsonl(&config.join("images.jsonl"));
+    let original_id = before[0]["id"].as_str().unwrap().to_string();
+    let original_sha = before[0]["sha256"].as_str().unwrap().to_string();
+    let file = fs::OpenOptions::new().write(true).open(&image).unwrap();
+    file.set_times(fs::FileTimes::new().set_modified(SystemTime::now() + Duration::from_secs(5)))
+        .unwrap();
+
+    // When: bootstrap observes only the modified time change.
+    assert_success(run(
+        &config,
+        &["bootstrap", "--path", image.to_str().unwrap()],
+    ));
+
+    // Then: append-only metadata advances while content identity stays stable.
+    let after = read_jsonl(&config.join("images.jsonl"));
+    assert_eq!(after.len(), 2);
+    assert_eq!(after[1]["id"], original_id);
+    assert_eq!(after[1]["sha256"], original_sha);
+    assert_ne!(after[1]["modified_at"], before[0]["modified_at"]);
+}
+
+#[test]
+fn bootstrap_content_change_preserves_id_and_marks_caption_stale() {
+    // Given: an indexed image with a caption for its original bytes.
+    let temp = tempfile::tempdir().unwrap();
+    let config = temp.path().join("state");
+    let image = temp.path().join("screen.png");
+    fs::write(&image, b"old image bytes").unwrap();
+    assert_success(run(&config, &["init"]));
+    assert_success(run(
+        &config,
+        &["bootstrap", "--path", image.to_str().unwrap()],
+    ));
+    let before = read_jsonl(&config.join("images.jsonl"));
+    let original_id = before[0]["id"].as_str().unwrap().to_string();
+    let caption = serde_json::json!({
+        "image_id": original_id,
+        "path": image.canonicalize().unwrap(),
+        "title": "Old Caption",
+        "description": "Only valid for the old bytes",
+        "model": "test",
+        "provider": "test",
+        "created_at": "2026-05-03T00:00:00Z",
+        "filename_meaningful": false
+    });
+    fs::write(config.join("captions.jsonl"), format!("{caption}\n")).unwrap();
+
+    // When: the same path is overwritten and bootstrap refreshes the index.
+    fs::write(&image, b"new image bytes with a different length").unwrap();
+    assert_success(run(
+        &config,
+        &["bootstrap", "--path", image.to_str().unwrap()],
+    ));
+
+    // Then: identity is stable, the old caption is excluded, and --missing selects the image.
+    let after = read_jsonl(&config.join("images.jsonl"));
+    assert_eq!(after.last().unwrap()["id"], original_id);
+    assert_ne!(after.last().unwrap()["sha256"], before[0]["sha256"]);
+    let search = assert_success(run(&config, &["search", "Old Caption"]));
+    assert!(search.trim().is_empty(), "stale caption leaked: {search}");
+    let missing = assert_success(run(&config, &["caption", "--missing", "--dry-run"]));
+    assert!(missing.contains("would caption"), "got: {missing}");
+}
+
+#[test]
+fn legacy_caption_for_replaced_image_id_is_not_current() {
+    // Given: state produced by the old behavior, where an overwrite replaced the image id.
+    let temp = tempfile::tempdir().unwrap();
+    let config = temp.path().join("state");
+    let image = temp.path().join("screen.png");
+    fs::write(&image, b"current image bytes").unwrap();
+    assert_success(run(&config, &["init"]));
+    assert_success(run(
+        &config,
+        &["bootstrap", "--path", image.to_str().unwrap()],
+    ));
+    let caption = serde_json::json!({
+        "image_id": "superseded-image-id",
+        "path": image.canonicalize().unwrap(),
+        "title": "Superseded Caption",
+        "description": "Caption belongs to the replaced id",
+        "model": "legacy",
+        "provider": "test",
+        "created_at": "2026-05-03T00:00:00Z",
+        "filename_meaningful": false
+    });
+    fs::write(config.join("captions.jsonl"), format!("{caption}\n")).unwrap();
+
+    // When: current caption consumers read the legacy state.
+    let search = assert_success(run(&config, &["search", "Superseded Caption"]));
+    let missing = assert_success(run(&config, &["caption", "--missing", "--dry-run"]));
+
+    // Then: the replaced id cannot make the current image look captioned.
+    assert!(search.trim().is_empty(), "stale caption leaked: {search}");
+    assert!(missing.contains("would caption"), "got: {missing}");
 }
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -245,10 +245,12 @@ fn sha_matched_caption_created_before_bootstrap_remains_current() {
     ));
     let search = assert_success(run(&config, &["search", "Pre Bootstrap Caption"]));
     let rename = assert_success(run(&config, &["rename", "--dry-run"]));
+    let missing = assert_success(run(&config, &["caption", "--missing", "--dry-run"]));
 
-    // Then: the SHA-bound caption remains usable despite its transient image id.
+    // Then: the SHA-bound caption remains usable and is not selected for a paid rerun.
     assert!(search.contains("screen.png"), "caption was lost: {search}");
     assert!(rename.contains("dry-run"), "caption was lost: {rename}");
+    assert_eq!(missing, "no images need captions\n");
 }
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -251,6 +251,65 @@ fn sha_matched_caption_created_before_bootstrap_remains_current() {
     assert!(search.contains("screen.png"), "caption was lost: {search}");
     assert!(rename.contains("dry-run"), "caption was lost: {rename}");
     assert_eq!(missing, "no images need captions\n");
+    let images = read_jsonl(&config.join("images.jsonl"));
+    let persisted_id = images[0]["id"].as_str().unwrap();
+    let last_caption = read_jsonl(&config.join("captions.jsonl"))
+        .pop()
+        .expect("normalized caption");
+    assert_eq!(last_caption["image_id"], persisted_id);
+}
+
+#[test]
+fn caption_file_refreshes_indexed_image_before_binding_sha() {
+    // Given: an indexed image whose bytes later change without a bootstrap.
+    let temp = tempfile::tempdir().unwrap();
+    let config = temp.path().join("state");
+    let image = temp.path().join("screen.png");
+    let new_bytes = b"captioned after overwrite without bootstrap";
+    fs::write(&image, b"original indexed bytes").unwrap();
+    assert_success(run(&config, &["init"]));
+    assert_success(run(
+        &config,
+        &["bootstrap", "--path", image.to_str().unwrap()],
+    ));
+    let before = read_jsonl(&config.join("images.jsonl"));
+    let original_id = before[0]["id"].as_str().unwrap().to_string();
+    let original_sha = before[0]["sha256"].as_str().unwrap().to_string();
+    fs::write(&image, new_bytes).unwrap();
+
+    // When: caption --file inspects the overwritten path before credentials fail.
+    let output = run(&config, &["caption", "--file", image.to_str().unwrap()]);
+    assert!(!output.status.success());
+
+    // Then: the persisted fingerprint matches the bytes that would be captioned.
+    let after = read_jsonl(&config.join("images.jsonl"));
+    let refreshed = after.last().unwrap();
+    assert_eq!(refreshed["id"], original_id);
+    assert_ne!(refreshed["sha256"], original_sha);
+    assert_eq!(
+        refreshed["sha256"],
+        format!("{:x}", Sha256::digest(new_bytes))
+    );
+    let caption = serde_json::json!({
+        "image_id": original_id,
+        "path": image.canonicalize().unwrap(),
+        "source_sha256": refreshed["sha256"],
+        "title": "Live File Caption",
+        "description": "Bound to the overwritten bytes",
+        "model": "test",
+        "provider": "test",
+        "created_at": "2026-08-17T00:00:00Z",
+        "filename_meaningful": false
+    });
+    fs::write(config.join("captions.jsonl"), format!("{caption}\n")).unwrap();
+    assert_success(run(
+        &config,
+        &["bootstrap", "--path", image.to_str().unwrap()],
+    ));
+    let search = assert_success(run(&config, &["search", "Live File Caption"]));
+    let missing = assert_success(run(&config, &["caption", "--missing", "--dry-run"]));
+    assert!(search.contains("screen.png"), "caption was lost: {search}");
+    assert_eq!(missing, "no images need captions\n");
 }
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -5,6 +5,7 @@ use std::{
     time::{Duration, SystemTime},
 };
 
+use sha2::{Digest, Sha256};
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 
@@ -213,6 +214,41 @@ fn legacy_caption_for_replaced_image_id_is_not_current() {
     // Then: the replaced id cannot make the current image look captioned.
     assert!(search.trim().is_empty(), "stale caption leaked: {search}");
     assert!(missing.contains("would caption"), "got: {missing}");
+}
+
+#[test]
+fn sha_matched_caption_created_before_bootstrap_remains_current() {
+    // Given: `caption --file` state created before the image is bootstrapped.
+    let temp = tempfile::tempdir().unwrap();
+    let config = temp.path().join("state");
+    let image = temp.path().join("screen.png");
+    let bytes = b"captioned before bootstrap";
+    fs::write(&image, bytes).unwrap();
+    assert_success(run(&config, &["init"]));
+    let caption = serde_json::json!({
+        "image_id": "transient-caption-image-id",
+        "path": image.canonicalize().unwrap(),
+        "source_sha256": format!("{:x}", Sha256::digest(bytes)),
+        "title": "Pre Bootstrap Caption",
+        "description": "Still valid for the identical file bytes",
+        "model": "test",
+        "provider": "test",
+        "created_at": "2026-08-17T00:00:00Z",
+        "filename_meaningful": false
+    });
+    fs::write(config.join("captions.jsonl"), format!("{caption}\n")).unwrap();
+
+    // When: bootstrap later assigns the persisted image id for the same bytes.
+    assert_success(run(
+        &config,
+        &["bootstrap", "--path", image.to_str().unwrap()],
+    ));
+    let search = assert_success(run(&config, &["search", "Pre Bootstrap Caption"]));
+    let rename = assert_success(run(&config, &["rename", "--dry-run"]));
+
+    // Then: the SHA-bound caption remains usable despite its transient image id.
+    assert!(search.contains("screen.png"), "caption was lost: {search}");
+    assert!(rename.contains("dry-run"), "caption was lost: {rename}");
 }
 
 #[test]

--- a/tests/vdr_cli.rs
+++ b/tests/vdr_cli.rs
@@ -555,7 +555,7 @@ fn vdr_sync_updates_vector_path_after_image_record_path_changes() {
 
 #[test]
 fn vdr_sync_reindexes_when_file_sha_changes() {
-    // Given: an indexed image whose bytes change without changing its path.
+    // Given: a synced image whose bytes change without changing its path.
     let server = FakeEmbeddingServer::start();
     let temp = tempfile::tempdir().expect("tempdir");
     let config = temp.path().join("state");
@@ -576,21 +576,88 @@ fn vdr_sync_reindexes_when_file_sha_changes() {
         &["vdr", "sync", "--dimensions", "4"],
         server.url(),
     ));
+    let requests_after_first_sync = server.request_count();
 
     fs::write(&image, b"dog image bytes changed").expect("modify image bytes");
 
-    // When: VDR sync runs again without a path change.
+    // When: VDR sync runs before and after bootstrap refreshes filesystem state.
+    let before_bootstrap = assert_success(run(
+        &config,
+        &["vdr", "sync", "--dimensions", "4"],
+        server.url(),
+    ));
+    assert_success(run(
+        &config,
+        &["bootstrap", "--path", images.to_str().expect("utf8")],
+        server.url(),
+    ));
+    let (refreshed_id, _) = image_id_for(&config, "dog.png");
     let synced = assert_success(run(
         &config,
         &["vdr", "sync", "--dimensions", "4"],
         server.url(),
     ));
 
-    // Then: image and caption vectors are refreshed for the new file sha.
+    // Then: VDR consumes bootstrap state, preserves identity, and refreshes only current content.
     assert!(
-        synced.contains("indexed 2"),
-        "changed same-path image should be re-indexed, got: {synced}"
+        before_bootstrap.contains("indexed 0"),
+        "sync must not rescan files, got: {before_bootstrap}"
     );
+    assert_eq!(server.request_count(), requests_after_first_sync + 1);
+    assert_eq!(refreshed_id, dog_id);
+    assert!(
+        synced.contains("indexed 1"),
+        "only the changed image should be re-indexed until recaptioned, got: {synced}"
+    );
+}
+
+#[test]
+fn vdr_failed_reindex_preserves_last_good_vectors() {
+    // Given: a fully indexed image whose bytes are later refreshed by bootstrap.
+    let initial_server = FakeEmbeddingServer::start();
+    let temp = tempfile::tempdir().expect("tempdir");
+    let config = temp.path().join("state");
+    let images = temp.path().join("images");
+    fs::create_dir_all(&images).expect("create images");
+    let image = images.join("dog.png");
+    fs::write(&image, b"dog image bytes").expect("write dog image");
+    assert_success(run(&config, &["init"], initial_server.url()));
+    assert_success(run(
+        &config,
+        &["bootstrap", "--path", images.to_str().expect("utf8")],
+        initial_server.url(),
+    ));
+    let (dog_id, dog_path) = image_id_for(&config, "dog.png");
+    write_caption(&config, &dog_id, &dog_path, "Dog", "puppy");
+    assert_success(run(
+        &config,
+        &["vdr", "sync", "--dimensions", "4"],
+        initial_server.url(),
+    ));
+    fs::write(&image, b"changed dog image bytes").expect("change dog image");
+    assert_success(run(
+        &config,
+        &["bootstrap", "--path", images.to_str().expect("utf8")],
+        initial_server.url(),
+    ));
+    let failing_server = FakeEmbeddingServer::start_with_statuses(vec![500]);
+
+    // When: replacement embedding fails before a new vector can be stored.
+    let failed = run(
+        &config,
+        &["vdr", "sync", "--dimensions", "4", "--max-retries", "0"],
+        failing_server.url(),
+    );
+
+    // Then: the last successful image and caption vectors remain active.
+    assert!(!failed.status.success(), "reindex should fail");
+    let status = assert_success(run(
+        &config,
+        &["vdr", "status", "--json"],
+        initial_server.url(),
+    ));
+    let status: serde_json::Value = serde_json::from_str(&status).expect("status json");
+    assert_eq!(status["active_vectors"], 2, "got: {status}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- skip file reads and SHA-256 work when size and mtime are unchanged
- preserve image IDs across metadata-only and content refreshes while making captions SHA-aware
- make VDR consume bootstrap state, stream hashing, and preserve last-good vectors on failed replacement
- keep legacy JSONL, prune, JSON search, rename safety, and pre-bootstrap `caption --file` workflows compatible

## Test evidence
- RED→GREEN regressions for unchanged reads, stable IDs, stale captions, streaming SHA, VDR bootstrap boundaries, failure atomicity, and pre-bootstrap captions
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace` (53 CLI tests, 16 VDR CLI tests, all workspace targets green)

## Live E2E
- unchanged mode-000 file: second bootstrap appended nothing and logged no read error
- mtime-only touch: ID/SHA stable and `caption --missing` skipped
- byte overwrite: ID stable, SHA changed, stale caption excluded and recaption selected
- prune/search/rename: deleted image inactive, JSON schema preserved, rename remained dry-run
- pre-bootstrap caption: transient ID normalized to persisted ID; search/rename retained it and `caption --missing` avoided duplicate paid work

## Review
Independent Codex review found two pre-bootstrap caption edge cases; both were reproduced RED, fixed, committed separately, and the final re-review passed with direct CLI validation.

Closes #12