### PR TITLE
feat(search): add V-SPLADE lexical retrieval and RRF hybrid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- V-SPLADE lexical search (`search --mode lexical`) via the MLX port in [SPLADE-mlx](https://github.com/NomaDamas/SPLADE-mlx)
+- `vdr sync|serve --backend vsplade` stores sparse `{indices,values}` postings alongside dense VDR vectors
+- Hybrid search now Reciprocal-Rank-Fuses keyword + lexical + embedding lists (empty lists are skipped)
+
 ## [0.1.2] — 2026-08-17
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -92,13 +92,14 @@ You'll need credentials for a provider (see [Vision model setup](#vision-model-s
 
 ### 3. Search
 
-By default, search is **hybrid**: it matches captions and filenames by keyword *and*, if you've built a visual index, finds images that *look* like your query.
+By default, search is **hybrid**: Reciprocal Rank Fusion over keyword matches, V-SPLADE lexical ranks (if you synced `--backend vsplade`), and dense VDR ranks (if you built a visual index).
 
 ```bash
 clawgallery search "login error"
 clawgallery search "login error" --json --limit 5
-clawgallery search --mode keyword "github actions"    # text only
-clawgallery search --mode embedding "sunset photo"    # visual only
+clawgallery search --mode keyword "github actions"    # caption/path text only
+clawgallery search --mode lexical "invoice total"     # V-SPLADE sparse retrieval
+clawgallery search --mode embedding "sunset photo"    # dense visual only
 ```
 
 Search understands fzf-style operators:
@@ -153,6 +154,18 @@ Or run it as a background service (see [Run as a background service](#run-as-a-b
 
 ---
 
+## Lexical search (V-SPLADE)
+
+[V-SPLADE](https://github.com/NomaDamas/SPLADE-mlx) encodes each page image into a sparse vocabulary vector. Queries are an inference-free lookup, then ClawGallery ranks by sparse dot product. This is the `--mode lexical` backend and one of the hybrid RRF lists.
+
+```bash
+CLAWGALLERY_PYTHON=/path/to/splade-mlx/.venv/bin/python \
+  clawgallery vdr sync --backend vsplade
+clawgallery search --mode lexical "invoice total"
+```
+
+Default model: `NomaDamas/v-splade-efficient-mlx` (Apache-2.0, 50368-dim vocabulary). Sparse postings are stored in `vdr.sqlite3` next to dense VDR rows and do not deactivate them.
+
 ## Visual search (VDR)
 
 "Visual Document Retrieval" is what lets ClawGallery find images by how they *look*, not just by their captions. It's optional — plain keyword search works without it — but it's what makes "find that screenshot of the error dialog" work even when the filename is garbage.
@@ -179,7 +192,8 @@ CLAWGALLERY_PYTHON="$(uv tool dir)/mlx-embeddings/bin/python" clawgallery vdr sy
 Then just search — the query is embedded automatically:
 
 ```bash
-clawgallery search "login error"              # hybrid (keyword + visual)
+clawgallery search "login error"              # hybrid RRF (keyword + lexical + visual)
+clawgallery search --mode lexical "invoice"   # V-SPLADE sparse retrieval
 clawgallery search --mode embedding "sunset"  # visual only
 clawgallery vdr status --json
 ```
@@ -350,9 +364,9 @@ clawgallery rename [--apply] [--dry-run] [--file <path>] [--style title|caption|
 clawgallery rename --undo [--last] [--file <path>] [--dry-run]
 clawgallery forget --file <path> [--delete]
 clawgallery dedup [--exact] [--similar] [--threshold <0..1>] [--json]
-clawgallery search [--mode keyword|embedding] <query...> [--limit <n>] [--json] [--case-sensitive] [--no-fuzzy] [--embedding-url <url>]
-clawgallery vdr sync [--prune] [--embedding-url <url>] [--model <model>] [--dimensions <n>] [--max-retries <n>] [--auto-start|--no-auto-start] [--backend mlx|jina-mlx] [--host <host>] [--port <port>] [--device auto|mps|cpu] [--python <path>] [--allow-remote]
-clawgallery vdr serve [--backend mlx|jina-mlx] [--host <host>] [--port <port>] [--model <model>] [--dimensions <n>] [--device auto|mps|cpu] [--python <path>] [--allow-remote]
+clawgallery search [--mode keyword|embedding|lexical|hybrid] <query...> [--limit <n>] [--json] [--case-sensitive] [--no-fuzzy] [--embedding-url <url>]
+clawgallery vdr sync [--prune] [--embedding-url <url>] [--model <model>] [--dimensions <n>] [--max-retries <n>] [--auto-start|--no-auto-start] [--backend mlx|jina-mlx|vsplade] [--host <host>] [--port <port>] [--device auto|mps|cpu] [--python <path>] [--allow-remote]
+clawgallery vdr serve [--backend mlx|jina-mlx|vsplade] [--host <host>] [--port <port>] [--model <model>] [--dimensions <n>] [--device auto|mps|cpu] [--python <path>] [--allow-remote]
 clawgallery vdr status [--json]
 clawgallery daemon install [--interval <seconds>] [--caption] [--sync] [--path <path>] [--folder <id>]
 clawgallery daemon start|stop|status|uninstall|logs

--- a/crates/clawgallery-vdr/src/client.rs
+++ b/crates/clawgallery-vdr/src/client.rs
@@ -20,6 +20,12 @@ pub(super) struct EmbedResponse {
     pub(super) embeddings: Vec<Vec<Vec<f32>>>,
 }
 
+#[derive(Debug)]
+pub(super) struct SparseEmbedResponse {
+    pub(super) model: String,
+    pub(super) embeddings: Vec<crate::sparse::SparseVector>,
+}
+
 #[derive(Debug, Deserialize)]
 struct RawEmbedResponse {
     model: String,
@@ -31,6 +37,8 @@ struct RawEmbedResponse {
 struct EmbedRequest {
     model: String,
     dimensions: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    format: Option<&'static str>,
     inputs: Vec<EmbedInput>,
 }
 
@@ -61,6 +69,7 @@ pub(super) fn embed_with_retries(
     let request = EmbedRequest {
         model: model.to_string(),
         dimensions,
+        format: None,
         inputs,
     };
     let client = reqwest::blocking::Client::new();
@@ -235,6 +244,57 @@ fn redact_message(message: &str) -> String {
         .map(redact_url)
         .collect::<Vec<_>>()
         .join(" ")
+}
+
+pub(super) fn embed_sparse(
+    url: &str,
+    model: &str,
+    dimensions: usize,
+    inputs: Vec<EmbedInput>,
+    max_retries: usize,
+) -> Result<SparseEmbedResponse> {
+    let endpoint = format!("{}/embed", url.trim_end_matches('/'));
+    let request = EmbedRequest {
+        model: model.to_string(),
+        dimensions,
+        format: Some("sparse"),
+        inputs,
+    };
+    let client = reqwest::blocking::Client::new();
+    let response = send_with_retry(&client, &endpoint, &request, max_retries).map_err(|err| {
+        anyhow!(
+            "{} at {}: {}",
+            err.context,
+            redact_url(url),
+            redact_message(&err.message)
+        )
+    })?;
+    let response: Value = response.json()?;
+    let raw: RawEmbedResponse = serde_json::from_value(response)?;
+    if raw.model != model {
+        bail!(
+            "embedding server returned model {} but {} was requested; pass --model/--dimensions matching the running server",
+            raw.model,
+            model
+        );
+    }
+    if let Some(response_dimensions) = raw.dimensions
+        && response_dimensions != dimensions
+    {
+        bail!(
+            "embedding server returned dimensions {} but {} was requested; pass --model/--dimensions matching the running server",
+            response_dimensions,
+            dimensions
+        );
+    }
+    let mut embeddings = Vec::with_capacity(raw.embeddings.len());
+    for value in raw.embeddings {
+        embeddings.push(crate::sparse::parse_sparse_vector(&value)?);
+    }
+    Ok(SparseEmbedResponse {
+        model: raw.model,
+        embeddings,
+    })
 }
 
 pub(super) fn query_input(query: &str) -> EmbedInput {

--- a/crates/clawgallery-vdr/src/index.rs
+++ b/crates/clawgallery-vdr/src/index.rs
@@ -19,8 +19,34 @@ pub struct VdrStatus {
 }
 
 pub(super) fn latest_active_index_config(conn: &Connection) -> Result<Option<ActiveIndexConfig>> {
-    Ok(conn
-        .query_row(
+    latest_index_config(conn, Some("dense"))
+}
+
+pub(super) fn latest_sparse_index_config(conn: &Connection) -> Result<Option<ActiveIndexConfig>> {
+    latest_index_config(conn, Some("sparse"))
+}
+
+pub(super) fn latest_any_index_config(conn: &Connection) -> Result<Option<ActiveIndexConfig>> {
+    latest_index_config(conn, None)
+}
+
+fn latest_index_config(
+    conn: &Connection,
+    encoding: Option<&str>,
+) -> Result<Option<ActiveIndexConfig>> {
+    let config = match encoding {
+        Some(encoding) => conn.query_row(
+            "select model, dimensions from vdr_embeddings
+             where active = 1 and encoding = ?1 order by indexed_at desc limit 1",
+            [encoding],
+            |row| {
+                Ok(ActiveIndexConfig {
+                    model: row.get(0)?,
+                    dimensions: row.get(1)?,
+                })
+            },
+        ),
+        None => conn.query_row(
             "select model, dimensions from vdr_embeddings
              where active = 1 order by indexed_at desc limit 1",
             [],
@@ -30,8 +56,9 @@ pub(super) fn latest_active_index_config(conn: &Connection) -> Result<Option<Act
                     dimensions: row.get(1)?,
                 })
             },
-        )
-        .optional()?)
+        ),
+    };
+    Ok(config.optional()?)
 }
 
 pub(super) fn status(db_path: &Path, active_images: usize, conn: &Connection) -> Result<VdrStatus> {
@@ -40,7 +67,7 @@ pub(super) fn status(db_path: &Path, active_images: usize, conn: &Connection) ->
         [],
         |row| row.get(0),
     )?;
-    let config = latest_active_index_config(conn)?;
+    let config = latest_any_index_config(conn)?;
     Ok(VdrStatus {
         active_images,
         active_vectors,

--- a/crates/clawgallery-vdr/src/lib.rs
+++ b/crates/clawgallery-vdr/src/lib.rs
@@ -10,15 +10,19 @@ mod duplicates;
 mod index;
 mod schema;
 mod search;
+mod sparse;
 mod store;
 
 pub use client::DEFAULT_MAX_RETRIES;
 pub use index::{ActiveIndexConfig, VdrStatus};
 pub use search::{EmbeddingSearchHit, late_interaction_score};
+pub use sparse::{SparseVector, rrf_score};
 
 pub const DEFAULT_EMBEDDING_URL: &str = "http://127.0.0.1:8765";
 pub const DEFAULT_VDR_MODEL: &str = "vidore/colqwen2-v1.0";
 pub const DEFAULT_DIMENSIONS: usize = 128;
+pub const DEFAULT_VSPLADE_MODEL: &str = "NomaDamas/v-splade-efficient-mlx";
+pub const DEFAULT_VSPLADE_DIMENSIONS: usize = 50368;
 const SYNC_EMBEDDING_BATCH_SIZE: usize = 1;
 
 #[derive(Debug, Clone)]
@@ -36,6 +40,13 @@ pub struct CaptionDocument {
     pub description: String,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum VectorEncoding {
+    #[default]
+    Dense,
+    Sparse,
+}
+
 #[derive(Debug, Clone)]
 pub struct SyncConfig {
     pub db_path: PathBuf,
@@ -44,6 +55,7 @@ pub struct SyncConfig {
     pub embedding_url: Option<String>,
     pub max_retries: usize,
     pub prune: bool,
+    pub encoding: VectorEncoding,
 }
 
 #[derive(Debug, Clone)]
@@ -119,8 +131,15 @@ pub fn sync(
         store::prune_inactive_vectors(&conn, &images)?;
     }
     store::update_active_vector_paths(&conn, &images, &config.model, config.dimensions)?;
-    let pending =
-        store::pending_embeddings(&conn, images, &captions, &config.model, config.dimensions)?;
+    let include_captions = config.encoding != VectorEncoding::Sparse;
+    let pending = store::pending_embeddings(
+        &conn,
+        images,
+        &captions,
+        &config.model,
+        config.dimensions,
+        include_captions,
+    )?;
     if pending.is_empty() {
         return Ok(SyncOutcome { indexed_vectors: 0 });
     }
@@ -135,28 +154,72 @@ pub fn sync(
                 value: item.value.clone(),
             })
             .collect();
-        let response = client::embed_with_retries(
-            &url,
-            &config.model,
-            config.dimensions,
-            inputs,
-            config.max_retries,
-        )?;
-        if response.embeddings.len() != batch.len() {
-            bail!(
-                "embedding server returned {} embedding(s) for {} input(s)",
-                response.embeddings.len(),
+        indexed_vectors += match config.encoding {
+            VectorEncoding::Dense => {
+                let response = client::embed_with_retries(
+                    &url,
+                    &config.model,
+                    config.dimensions,
+                    inputs,
+                    config.max_retries,
+                )?;
+                if response.embeddings.len() != batch.len() {
+                    bail!(
+                        "embedding server returned {} embedding(s) for {} input(s)",
+                        response.embeddings.len(),
+                        batch.len()
+                    );
+                }
+                for (item, vector) in batch.iter().zip(response.embeddings) {
+                    let tx = conn.unchecked_transaction()?;
+                    store::deactivate_stale_vectors(
+                        &tx,
+                        &item.image_id,
+                        &item.sha256,
+                        &config.model,
+                    )?;
+                    store::deactivate_existing_kind(&tx, &item.image_id, item.kind, &config.model)?;
+                    store::insert_vector(&tx, item, &response.model, config.dimensions, &vector)?;
+                    tx.commit()?;
+                }
                 batch.len()
-            );
-        }
-        indexed_vectors += response.embeddings.len();
-        for (item, vector) in batch.iter().zip(response.embeddings) {
-            let tx = conn.unchecked_transaction()?;
-            store::deactivate_stale_vectors(&tx, &item.image_id, &item.sha256)?;
-            store::deactivate_existing_kind(&tx, &item.image_id, item.kind)?;
-            store::insert_vector(&tx, item, &response.model, config.dimensions, &vector)?;
-            tx.commit()?;
-        }
+            }
+            VectorEncoding::Sparse => {
+                let response = client::embed_sparse(
+                    &url,
+                    &config.model,
+                    config.dimensions,
+                    inputs,
+                    config.max_retries,
+                )?;
+                if response.embeddings.len() != batch.len() {
+                    bail!(
+                        "embedding server returned {} embedding(s) for {} input(s)",
+                        response.embeddings.len(),
+                        batch.len()
+                    );
+                }
+                for (item, vector) in batch.iter().zip(response.embeddings) {
+                    let tx = conn.unchecked_transaction()?;
+                    store::deactivate_stale_vectors(
+                        &tx,
+                        &item.image_id,
+                        &item.sha256,
+                        &config.model,
+                    )?;
+                    store::deactivate_existing_kind(&tx, &item.image_id, item.kind, &config.model)?;
+                    store::insert_sparse_vector(
+                        &tx,
+                        item,
+                        &response.model,
+                        config.dimensions,
+                        &vector,
+                    )?;
+                    tx.commit()?;
+                }
+                batch.len()
+            }
+        };
     }
     Ok(SyncOutcome { indexed_vectors })
 }
@@ -172,8 +235,14 @@ pub fn pending_embedding_count(
         store::prune_inactive_vectors(&conn, &images)?;
     }
     store::update_active_vector_paths(&conn, &images, &config.model, config.dimensions)?;
-    let pending =
-        store::pending_embeddings(&conn, images, &captions, &config.model, config.dimensions)?;
+    let pending = store::pending_embeddings(
+        &conn,
+        images,
+        &captions,
+        &config.model,
+        config.dimensions,
+        config.encoding != VectorEncoding::Sparse,
+    )?;
     Ok(pending.len())
 }
 
@@ -184,6 +253,37 @@ pub fn embedding_search(
     captions: Vec<CaptionDocument>,
 ) -> Result<Vec<EmbeddingSearchHit>> {
     search::embedding_search(config, query, images, captions)
+}
+
+pub fn lexical_search(
+    config: &SearchConfig,
+    query: &str,
+    images: Vec<ImageDocument>,
+    captions: Vec<CaptionDocument>,
+) -> Result<Vec<EmbeddingSearchHit>> {
+    search::lexical_search(config, query, images, captions)
+}
+
+pub fn latest_sparse_index_config(db_path: &Path) -> Result<Option<ActiveIndexConfig>> {
+    latest_index_config(db_path, VectorEncoding::Sparse)
+}
+
+pub fn latest_dense_index_config(db_path: &Path) -> Result<Option<ActiveIndexConfig>> {
+    latest_index_config(db_path, VectorEncoding::Dense)
+}
+
+fn latest_index_config(
+    db_path: &Path,
+    encoding: VectorEncoding,
+) -> Result<Option<ActiveIndexConfig>> {
+    if !db_path.exists() {
+        return Ok(None);
+    }
+    let conn = store::open_store(db_path)?;
+    match encoding {
+        VectorEncoding::Dense => index::latest_active_index_config(&conn),
+        VectorEncoding::Sparse => index::latest_sparse_index_config(&conn),
+    }
 }
 
 pub fn status(db_path: &Path, active_images: usize) -> Result<VdrStatus> {

--- a/crates/clawgallery-vdr/src/schema.rs
+++ b/crates/clawgallery-vdr/src/schema.rs
@@ -14,6 +14,7 @@ pub(super) fn ensure_schema(conn: &Connection) -> Result<()> {
             dimensions integer not null,
             content_hash text not null default '',
             vector_json text not null,
+            encoding text not null default 'dense',
             active integer not null,
             indexed_at text not null
         );
@@ -24,7 +25,8 @@ pub(super) fn ensure_schema(conn: &Connection) -> Result<()> {
         create index if not exists vdr_embeddings_active
             on vdr_embeddings(active);",
     )?;
-    migrate_content_hash(conn)
+    migrate_content_hash(conn)?;
+    migrate_encoding(conn)
 }
 
 pub(super) fn content_hash(value: &str) -> String {
@@ -42,14 +44,29 @@ pub(super) fn parse_stored_vectors(vector_json: &str) -> Result<Vec<Vec<f32>>> {
     }
 }
 
-fn migrate_content_hash(conn: &Connection) -> Result<()> {
+fn table_columns(conn: &Connection) -> Result<Vec<String>> {
     let mut stmt = conn.prepare("pragma table_info(vdr_embeddings)")?;
-    let columns = stmt
+    Ok(stmt
         .query_map([], |row| row.get::<_, String>(1))?
-        .collect::<rusqlite::Result<Vec<_>>>()?;
+        .collect::<rusqlite::Result<Vec<_>>>()?)
+}
+
+fn migrate_content_hash(conn: &Connection) -> Result<()> {
+    let columns = table_columns(conn)?;
     if !columns.iter().any(|column| column == "content_hash") {
         conn.execute(
             "alter table vdr_embeddings add column content_hash text not null default ''",
+            [],
+        )?;
+    }
+    Ok(())
+}
+
+fn migrate_encoding(conn: &Connection) -> Result<()> {
+    let columns = table_columns(conn)?;
+    if !columns.iter().any(|column| column == "encoding") {
+        conn.execute(
+            "alter table vdr_embeddings add column encoding text not null default 'dense'",
             [],
         )?;
     }

--- a/crates/clawgallery-vdr/src/search.rs
+++ b/crates/clawgallery-vdr/src/search.rs
@@ -3,9 +3,9 @@ use anyhow::{Result, bail};
 use std::{collections::HashMap, path::PathBuf};
 
 use super::{
-    client::{default_model, embed, query_input, resolve_embedding_url},
-    index::{ActiveIndexConfig, latest_active_index_config},
-    store::{active_vectors, open_store},
+    client::{default_model, embed, embed_sparse, query_input, resolve_embedding_url},
+    index::{ActiveIndexConfig, latest_active_index_config, latest_sparse_index_config},
+    store::{active_sparse_vectors, active_vectors, open_store},
 };
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -127,6 +127,93 @@ pub fn late_interaction_score(query: &[Vec<f32>], document: &[Vec<f32>]) -> Resu
         total += best;
     }
     Ok(total / query.len() as f64)
+}
+
+pub(super) fn lexical_search(
+    config: &SearchConfig,
+    query: &str,
+    images: Vec<ImageDocument>,
+    captions: Vec<CaptionDocument>,
+) -> Result<Vec<EmbeddingSearchHit>> {
+    let conn = open_store(&config.db_path)?;
+    let url = resolve_embedding_url(config.embedding_url.as_deref());
+    let index_config = match (config.model.clone(), config.dimensions) {
+        (Some(model), Some(dimensions)) => ActiveIndexConfig { model, dimensions },
+        _ => latest_sparse_index_config(&conn)?.unwrap_or_else(default_sparse_index_config),
+    };
+    let active_images: HashMap<String, ImageDocument> = images
+        .into_iter()
+        .map(|image| (image.id.clone(), image))
+        .collect();
+    let stored = active_sparse_vectors(
+        &conn,
+        &active_images,
+        &index_config.model,
+        index_config.dimensions,
+    )?;
+    if stored.is_empty() {
+        return Ok(Vec::new());
+    }
+    let response = embed_sparse(
+        &url,
+        &index_config.model,
+        index_config.dimensions,
+        vec![query_input(query)],
+        crate::DEFAULT_MAX_RETRIES,
+    )?;
+    let query_vector = response
+        .embeddings
+        .into_iter()
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("embedding server returned no query embedding"))?;
+    let captions: HashMap<PathBuf, CaptionDocument> = captions
+        .into_iter()
+        .map(|caption| (caption.path.clone(), caption))
+        .collect();
+    let mut best_by_image = HashMap::new();
+    for stored in stored {
+        let Some(image) = active_images.get(&stored.image_id) else {
+            continue;
+        };
+        let score = query_vector.dot(&stored.vector);
+        let caption = captions.get(&image.path);
+        let hit = EmbeddingSearchHit {
+            path: image.path.clone(),
+            title: caption
+                .map(|c| c.title.clone())
+                .unwrap_or_else(|| "<missing>".to_string()),
+            description: caption
+                .map(|c| c.description.clone())
+                .unwrap_or_else(|| "<missing>".to_string()),
+            score,
+            matched_field: "lexical_image",
+            matched_atoms: vec![query.to_string()],
+            source: "lexical",
+        };
+        best_by_image
+            .entry(stored.image_id)
+            .and_modify(|existing: &mut EmbeddingSearchHit| {
+                if hit.score > existing.score {
+                    *existing = hit.clone();
+                }
+            })
+            .or_insert(hit);
+    }
+    let mut hits: Vec<_> = best_by_image.into_values().collect();
+    hits.sort_by(|a, b| {
+        b.score
+            .total_cmp(&a.score)
+            .then_with(|| a.path.cmp(&b.path))
+    });
+    hits.truncate(config.limit);
+    Ok(hits)
+}
+
+fn default_sparse_index_config() -> ActiveIndexConfig {
+    ActiveIndexConfig {
+        model: crate::DEFAULT_VSPLADE_MODEL.to_string(),
+        dimensions: crate::DEFAULT_VSPLADE_DIMENSIONS,
+    }
 }
 
 fn cosine_similarity(left: &[f32], right: &[f32]) -> Result<f64> {

--- a/crates/clawgallery-vdr/src/search.rs
+++ b/crates/clawgallery-vdr/src/search.rs
@@ -176,6 +176,9 @@ pub(super) fn lexical_search(
             continue;
         };
         let score = query_vector.dot(&stored.vector);
+        if score <= 0.0 {
+            continue;
+        }
         let caption = captions.get(&image.path);
         let hit = EmbeddingSearchHit {
             path: image.path.clone(),

--- a/crates/clawgallery-vdr/src/sparse.rs
+++ b/crates/clawgallery-vdr/src/sparse.rs
@@ -1,0 +1,102 @@
+use anyhow::{Result, bail};
+use serde::{Deserialize, Serialize};
+use std::cmp::Ordering;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SparseVector {
+    pub indices: Vec<u32>,
+    pub values: Vec<f32>,
+}
+
+impl SparseVector {
+    pub fn new(mut indices: Vec<u32>, mut values: Vec<f32>) -> Result<Self> {
+        if indices.len() != values.len() {
+            bail!(
+                "sparse vector length mismatch: {} indices vs {} values",
+                indices.len(),
+                values.len()
+            );
+        }
+        let mut order: Vec<usize> = (0..indices.len()).collect();
+        order.sort_by_key(|&i| indices[i]);
+        let mut sorted_indices = Vec::with_capacity(indices.len());
+        let mut sorted_values = Vec::with_capacity(values.len());
+        let mut last: Option<u32> = None;
+        for i in order {
+            let index = indices[i];
+            if last == Some(index) {
+                let acc = sorted_values.last_mut().expect("duplicate has prior value");
+                *acc += values[i];
+                continue;
+            }
+            last = Some(index);
+            sorted_indices.push(index);
+            sorted_values.push(values[i]);
+        }
+        indices = sorted_indices;
+        values = sorted_values;
+        Ok(Self { indices, values })
+    }
+
+    pub fn dot(&self, other: &Self) -> f64 {
+        let mut i = 0;
+        let mut j = 0;
+        let mut acc = 0.0_f64;
+        while i < self.indices.len() && j < other.indices.len() {
+            match self.indices[i].cmp(&other.indices[j]) {
+                Ordering::Less => i += 1,
+                Ordering::Greater => j += 1,
+                Ordering::Equal => {
+                    acc += f64::from(self.values[i]) * f64::from(other.values[j]);
+                    i += 1;
+                    j += 1;
+                }
+            }
+        }
+        acc
+    }
+}
+
+pub fn parse_sparse_vector(value: &serde_json::Value) -> Result<SparseVector> {
+    let Some(object) = value.as_object() else {
+        bail!("sparse embedding must be an object with indices and values");
+    };
+    let indices: Vec<u32> = match object.get("indices") {
+        Some(indices) => serde_json::from_value(indices.clone())?,
+        None => bail!("sparse embedding missing indices"),
+    };
+    let values: Vec<f32> = match object.get("values") {
+        Some(values) => serde_json::from_value(values.clone())?,
+        None => bail!("sparse embedding missing values"),
+    };
+    SparseVector::new(indices, values)
+}
+
+pub fn rrf_score(rank: usize) -> f64 {
+    1.0 / (60.0 + rank as f64 + 1.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sparse_dot_scores_overlapping_terms() {
+        let query = SparseVector::new(vec![1, 3], vec![1.0, 2.0]).unwrap();
+        let document = SparseVector::new(vec![3, 8], vec![0.5, 9.0]).unwrap();
+        assert_eq!(query.dot(&document), 1.0);
+    }
+
+    #[test]
+    fn sparse_dot_is_zero_without_overlap() {
+        let left = SparseVector::new(vec![1], vec![4.0]).unwrap();
+        let right = SparseVector::new(vec![2], vec![4.0]).unwrap();
+        assert_eq!(left.dot(&right), 0.0);
+    }
+
+    #[test]
+    fn rrf_prefers_earlier_ranks() {
+        assert!(rrf_score(0) > rrf_score(1));
+        assert_eq!(rrf_score(0), 1.0 / 61.0);
+    }
+}

--- a/crates/clawgallery-vdr/src/store.rs
+++ b/crates/clawgallery-vdr/src/store.rs
@@ -7,7 +7,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use super::{EmbeddingKind, PendingEmbedding, schema};
+use super::{EmbeddingKind, PendingEmbedding, schema, sparse::SparseVector};
 
 pub(super) fn open_store(db_path: &Path) -> Result<Connection> {
     if let Some(parent) = db_path.parent() {
@@ -41,6 +41,7 @@ pub(super) fn pending_embeddings(
     captions: &HashMap<PathBuf, CaptionDocument>,
     model: &str,
     dimensions: usize,
+    include_captions: bool,
 ) -> Result<Vec<PendingEmbedding>> {
     let mut pending = Vec::new();
     for image in images {
@@ -62,7 +63,7 @@ pub(super) fn pending_embeddings(
                 value: image.path.display().to_string(),
             });
         }
-        if let Some(caption) = captions.get(&image.path) {
+        if include_captions && let Some(caption) = captions.get(&image.path) {
             let caption_text = caption_text(caption);
             let caption_hash = schema::content_hash(&caption_text);
             if !has_current_vector(
@@ -92,10 +93,11 @@ pub(super) fn deactivate_existing_kind(
     conn: &Connection,
     image_id: &str,
     kind: EmbeddingKind,
+    model: &str,
 ) -> Result<()> {
     conn.execute(
-        "update vdr_embeddings set active = 0 where image_id = ?1 and kind = ?2",
-        params![image_id, kind.as_str()],
+        "update vdr_embeddings set active = 0 where image_id = ?1 and kind = ?2 and model = ?3",
+        params![image_id, kind.as_str(), model],
     )?;
     Ok(())
 }
@@ -135,11 +137,12 @@ pub(super) fn deactivate_stale_vectors(
     conn: &Connection,
     image_id: &str,
     sha256: &str,
+    model: &str,
 ) -> Result<()> {
     conn.execute(
         "update vdr_embeddings set active = 0
-         where image_id = ?1 and sha256 <> ?2 and active = 1",
-        params![image_id, sha256],
+         where image_id = ?1 and sha256 <> ?2 and active = 1 and model = ?3",
+        params![image_id, sha256, model],
     )?;
     Ok(())
 }
@@ -151,11 +154,46 @@ pub(super) fn insert_vector(
     dimensions: usize,
     vectors: &[Vec<f32>],
 ) -> Result<()> {
+    insert_encoded_vector(
+        conn,
+        item,
+        model,
+        dimensions,
+        "dense",
+        &serde_json::to_value(vectors)?,
+    )
+}
+
+pub(super) fn insert_sparse_vector(
+    conn: &Connection,
+    item: &PendingEmbedding,
+    model: &str,
+    dimensions: usize,
+    vector: &SparseVector,
+) -> Result<()> {
+    insert_encoded_vector(
+        conn,
+        item,
+        model,
+        dimensions,
+        "sparse",
+        &serde_json::to_value(vector)?,
+    )
+}
+
+fn insert_encoded_vector(
+    conn: &Connection,
+    item: &PendingEmbedding,
+    model: &str,
+    dimensions: usize,
+    encoding: &str,
+    vector_json: &serde_json::Value,
+) -> Result<()> {
     let path = item.path.to_string_lossy();
     conn.execute(
         "insert into vdr_embeddings
-         (image_id, path, sha256, kind, model, dimensions, content_hash, vector_json, active, indexed_at)
-         values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, 1, ?9)",
+         (image_id, path, sha256, kind, model, dimensions, content_hash, vector_json, encoding, active, indexed_at)
+         values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, 1, ?10)",
         params![
             item.image_id,
             path.as_ref(),
@@ -164,7 +202,8 @@ pub(super) fn insert_vector(
             model,
             dimensions,
             item.content_hash,
-            serde_json::to_string(vectors)?,
+            vector_json.to_string(),
+            encoding,
             Utc::now().to_rfc3339()
         ],
     )?;
@@ -179,7 +218,7 @@ pub(super) fn active_vectors(
 ) -> Result<Vec<StoredVector>> {
     let mut stmt = conn.prepare(
         "select image_id, kind, vector_json from vdr_embeddings
-         where active = 1 and model = ?1 and dimensions = ?2",
+         where active = 1 and encoding = 'dense' and model = ?1 and dimensions = ?2",
     )?;
     let rows = stmt.query_map(params![model, dimensions], |row| {
         let image_id: String = row.get(0)?;
@@ -237,9 +276,52 @@ fn caption_text(caption: &CaptionDocument) -> String {
     format!("{}\n{}", caption.title, caption.description)
 }
 
+pub(super) fn active_sparse_vectors(
+    conn: &Connection,
+    active_images: &HashMap<String, ImageDocument>,
+    model: &str,
+    dimensions: usize,
+) -> Result<Vec<StoredSparseVector>> {
+    let mut stmt = conn.prepare(
+        "select image_id, kind, vector_json from vdr_embeddings
+         where active = 1 and encoding = 'sparse' and model = ?1 and dimensions = ?2",
+    )?;
+    let rows = stmt.query_map(params![model, dimensions], |row| {
+        let image_id: String = row.get(0)?;
+        let kind: String = row.get(1)?;
+        let vector_json: String = row.get(2)?;
+        Ok((image_id, kind, vector_json))
+    })?;
+    let mut vectors = Vec::new();
+    for row in rows {
+        let (image_id, kind, vector_json) = row?;
+        if !active_images.contains_key(&image_id) {
+            continue;
+        }
+        let kind = match kind.as_str() {
+            "image" => EmbeddingKind::Image,
+            "caption" => EmbeddingKind::Caption,
+            _ => continue,
+        };
+        let value: serde_json::Value = serde_json::from_str(&vector_json)?;
+        let _ = kind;
+        vectors.push(StoredSparseVector {
+            image_id,
+            vector: crate::sparse::parse_sparse_vector(&value)?,
+        });
+    }
+    Ok(vectors)
+}
+
 #[derive(Debug)]
 pub(super) struct StoredVector {
     pub(super) image_id: String,
     pub(super) kind: EmbeddingKind,
     pub(super) vectors: Vec<Vec<f32>>,
+}
+
+#[derive(Debug)]
+pub(super) struct StoredSparseVector {
+    pub(super) image_id: String,
+    pub(super) vector: SparseVector,
 }

--- a/crates/clawgallery-vdr/src/store.rs
+++ b/crates/clawgallery-vdr/src/store.rs
@@ -283,28 +283,21 @@ pub(super) fn active_sparse_vectors(
     dimensions: usize,
 ) -> Result<Vec<StoredSparseVector>> {
     let mut stmt = conn.prepare(
-        "select image_id, kind, vector_json from vdr_embeddings
+        "select image_id, vector_json from vdr_embeddings
          where active = 1 and encoding = 'sparse' and model = ?1 and dimensions = ?2",
     )?;
     let rows = stmt.query_map(params![model, dimensions], |row| {
         let image_id: String = row.get(0)?;
-        let kind: String = row.get(1)?;
-        let vector_json: String = row.get(2)?;
-        Ok((image_id, kind, vector_json))
+        let vector_json: String = row.get(1)?;
+        Ok((image_id, vector_json))
     })?;
     let mut vectors = Vec::new();
     for row in rows {
-        let (image_id, kind, vector_json) = row?;
+        let (image_id, vector_json) = row?;
         if !active_images.contains_key(&image_id) {
             continue;
         }
-        let kind = match kind.as_str() {
-            "image" => EmbeddingKind::Image,
-            "caption" => EmbeddingKind::Caption,
-            _ => continue,
-        };
         let value: serde_json::Value = serde_json::from_str(&vector_json)?;
-        let _ = kind;
         vectors.push(StoredSparseVector {
             image_id,
             vector: crate::sparse::parse_sparse_vector(&value)?,

--- a/crates/clawgallery-vdr/tests/reusable_api.rs
+++ b/crates/clawgallery-vdr/tests/reusable_api.rs
@@ -1,5 +1,5 @@
 use clawgallery_vdr::{
-    CaptionDocument, DEFAULT_MAX_RETRIES, ImageDocument, SearchConfig, SyncConfig,
+    CaptionDocument, DEFAULT_MAX_RETRIES, ImageDocument, SearchConfig, SyncConfig, VectorEncoding,
     embedding_search, status, sync,
 };
 use std::{
@@ -36,6 +36,7 @@ fn reusable_vdr_api_indexes_and_searches_documents() {
             embedding_url: Some(server.url().to_string()),
             max_retries: DEFAULT_MAX_RETRIES,
             prune: true,
+            encoding: VectorEncoding::Dense,
         },
         images.clone(),
         captions.clone(),

--- a/scripts/vsplade_server.py
+++ b/scripts/vsplade_server.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""V-SPLADE sparse lexical embedding server for ClawGallery.
+
+Speaks the ClawGallery POST /embed contract, but returns sparse postings:
+``{"indices":[int,...],"values":[float,...]}`` per input instead of dense
+multi-vectors. Document images are encoded with the MLX V-SPLADE encoder;
+queries use the inference-free Li-LSR lookup table.
+
+Requires a Python env with splade-mlx, mlx, transformers, numpy, and pillow.
+"""
+from __future__ import annotations
+
+import argparse
+import ipaddress
+import json
+import os
+import re
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+VALID_KINDS = {"image", "text", "caption"}
+DEFAULT_MODEL = "NomaDamas/v-splade-efficient-mlx"
+DEFAULT_DIMENSIONS = 50368
+DOC_PROMPT = "User:<image><end_of_utterance>\nAssistant:"
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8765)
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument("--dimensions", type=int, default=DEFAULT_DIMENSIONS)
+    parser.add_argument("--device", default="auto", choices=["auto", "mps", "cpu"])
+    parser.add_argument(
+        "--allow-remote",
+        action="store_true",
+        help="allow binding this unauthenticated local-file-reading server to a non-loopback host",
+    )
+    return parser.parse_args()
+
+
+def is_loopback_host(host):
+    if host == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
+def validate_bind_host(args):
+    if is_loopback_host(args.host) or args.allow_remote:
+        return
+    raise SystemExit(
+        "error: refusing to bind unauthenticated /embed server to non-loopback host "
+        f"{args.host!r} without --allow-remote; this server can read arbitrary "
+        "local files requested by clients"
+    )
+
+
+def fake_sparse(value, dimensions):
+    haystack = value.lower()
+    if "dog" in haystack or "puppy" in haystack:
+        index = 1
+        weight = 2.0
+    elif "cat" in haystack or "kitten" in haystack:
+        index = 2
+        weight = 2.0
+    elif "login" in haystack:
+        index = 3
+        weight = 2.0
+    else:
+        tokens = [tok for tok in re.split(r"[^a-z0-9]+", haystack) if tok]
+        index = sum(ord(char) for char in (tokens[0] if tokens else "x")) % max(dimensions, 1)
+        weight = 1.0
+    index = min(index, max(dimensions, 1) - 1)
+    return {"indices": [index], "values": [weight]}
+
+
+def to_sparse(vector, dimensions):
+    import numpy as np
+
+    dense = np.asarray(vector, dtype=np.float32).reshape(-1)
+    if dense.size > dimensions:
+        dense = dense[:dimensions]
+    mask = dense > 0.0
+    indices = np.nonzero(mask)[0]
+    return {
+        "indices": indices.astype(int).tolist(),
+        "values": dense[indices].astype(float).tolist(),
+    }
+
+
+def make_server(model_name, dimensions, _device):
+    fake = os.environ.get("CLAWGALLERY_VDR_VSPLADE_FAKE") == "1"
+    model = query_encoder = processor = None
+    if not fake:
+        import mlx.core as mx
+        import numpy as np
+        from PIL import Image
+        from splade_mlx.convert_vsplade import load_vsplade
+
+        model, query_encoder, processor = load_vsplade(model_name)
+        vocab = int(query_encoder.num_dimensions)
+        if dimensions != vocab:
+            raise SystemExit(
+                f"error: V-SPLADE model {model_name} has vocabulary {vocab}, "
+                f"but --dimensions {dimensions} was requested"
+            )
+
+        def encode_image(path):
+            with Image.open(path) as image:
+                rgb = image.convert("RGB")
+                enc = processor(
+                    text=[DOC_PROMPT],
+                    images=[[rgb]],
+                    return_tensors="np",
+                )
+            pixel_values = enc["pixel_values"].astype("float32")
+            sparse = model.encode(
+                mx.array(enc["input_ids"]),
+                mx.array(enc["attention_mask"]),
+                pixel_values,
+            )
+            mx.eval(sparse)
+            return to_sparse(np.array(sparse.astype(mx.float32))[0], dimensions)
+
+        def encode_query(text):
+            encoded = processor.tokenizer([text], return_tensors="np")
+            weights = query_encoder.encode(encoded["input_ids"], encoded["attention_mask"])
+            return to_sparse(weights[0], dimensions)
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, format, *args):
+            return
+
+        def do_POST(self):
+            if self.path != "/embed":
+                self.send_error(404, "not found")
+                return
+            length = int(self.headers.get("content-length", "0"))
+            payload = json.loads(self.rfile.read(length))
+
+            def send_json(status, body):
+                encoded = json.dumps(body).encode()
+                self.send_response(status)
+                self.send_header("content-type", "application/json")
+                self.send_header("content-length", str(len(encoded)))
+                self.end_headers()
+                self.wfile.write(encoded)
+
+            requested_model = payload.get("model") or model_name
+            if requested_model != model_name:
+                send_json(
+                    400,
+                    {
+                        "error": (
+                            f"server loaded {model_name} but client requested {requested_model}"
+                        )
+                    },
+                )
+                return
+            requested_dimensions = payload.get("dimensions", dimensions)
+            if requested_dimensions != dimensions:
+                send_json(
+                    400,
+                    {
+                        "error": (
+                            f"server loaded dimensions {dimensions} but client "
+                            f"requested {requested_dimensions}"
+                        )
+                    },
+                )
+                return
+
+            embeddings = []
+            try:
+                for item in payload.get("inputs", []):
+                    kind = item.get("kind")
+                    if kind not in VALID_KINDS:
+                        send_json(
+                            400,
+                            {
+                                "error": (
+                                    f"invalid input kind {kind!r}; expected image, text, or caption"
+                                )
+                            },
+                        )
+                        return
+                    value = str(item.get("value") or "")
+                    role = str(item.get("role") or "")
+                    if fake:
+                        haystack = Path(value).name if kind == "image" else value
+                        embeddings.append(fake_sparse(haystack, dimensions))
+                        continue
+                    if kind == "image" or (kind == "caption" and role == "document"):
+                        embeddings.append(encode_image(value) if kind == "image" else encode_query(value))
+                    else:
+                        embeddings.append(encode_query(value))
+            except Exception as exc:  # noqa: BLE001 - surface encoder failures to the client
+                send_json(500, {"error": str(exc)})
+                return
+
+            send_json(
+                200,
+                {
+                    "model": model_name,
+                    "dimensions": dimensions,
+                    "format": "sparse",
+                    "embeddings": embeddings,
+                },
+            )
+
+    return Handler
+
+
+def main():
+    args = parse_args()
+    validate_bind_host(args)
+    handler = make_server(args.model, args.dimensions, args.device)
+    server = ThreadingHTTPServer((args.host, args.port), handler)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/clawgallery/SKILL.md
+++ b/skills/clawgallery/SKILL.md
@@ -71,7 +71,19 @@ clawgallery search "'github" "actions" --json
 clawgallery search "!error" "^login"
 ```
 
-Search atoms follow fzf-like rules for the keyword side: whitespace means AND, `'foo` exact substring, `^foo` prefix, `foo$` suffix, `!foo` exclusion, and `\ ` literal space. When a VDR index exists, default search also runs embedding search and fuses both rankings. Add `--mode keyword` for caption/path keyword search only, `--mode embedding` for VDR only, or `--no-fuzzy` for old exact-substring behavior.
+Search atoms follow fzf-like rules for the keyword side: whitespace means AND, `'foo` exact substring, `^foo` prefix, `foo$` suffix, `!foo` exclusion, and `\ ` literal space. When a VDR or V-SPLADE index exists, default search fuses those rankings with keyword search via Reciprocal Rank Fusion. Add `--mode keyword` for caption/path keyword search only, `--mode lexical` for V-SPLADE sparse retrieval, `--mode embedding` for dense VDR only, or `--no-fuzzy` for old exact-substring behavior.
+
+## V-SPLADE lexical search
+
+Use the MLX V-SPLADE runtime from [SPLADE-mlx](https://github.com/NomaDamas/SPLADE-mlx) for sparse visual-lexical retrieval. Point `CLAWGALLERY_PYTHON` at an environment with `splade-mlx`, `mlx`, `transformers`, `numpy`, and `pillow`:
+
+```bash
+CLAWGALLERY_PYTHON=/path/to/splade-mlx/.venv/bin/python \
+  clawgallery vdr sync --backend vsplade
+clawgallery search --mode lexical "invoice total" --json
+```
+
+Default model `NomaDamas/v-splade-efficient-mlx`, dimensions `50368`. The index stores sparse `{indices,values}` postings and can coexist with a dense VDR index. Hybrid search fuses keyword + lexical + embedding ranks with RRF (`k=60`).
 
 ## VDR model setup
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -325,6 +325,7 @@ enum SearchMode {
     Hybrid,
     Keyword,
     Embedding,
+    Lexical,
 }
 
 #[derive(Debug, Subcommand)]
@@ -1595,6 +1596,7 @@ enum HitSource {
     Levenshtein,
     NoFuzzy,
     Embedding,
+    Lexical,
     Hybrid,
 }
 
@@ -1979,6 +1981,11 @@ fn search_result_from_keyword_hit(hit: &SearchHit, candidate: &SearchCandidate) 
 }
 
 fn search_result_from_embedding_hit(hit: clawgallery_vdr::EmbeddingSearchHit) -> SearchResult {
+    let source = if hit.source == "lexical" {
+        HitSource::Lexical
+    } else {
+        HitSource::Embedding
+    };
     SearchResult {
         path_raw: hit.path,
         title: hit.title,
@@ -1987,7 +1994,7 @@ fn search_result_from_embedding_hit(hit: clawgallery_vdr::EmbeddingSearchHit) ->
         pattern_score: 0,
         matched_field: hit.matched_field.to_string(),
         matched_atoms: hit.matched_atoms,
-        source: HitSource::Embedding,
+        source,
         discovered_at: Utc::now(),
     }
 }
@@ -2067,38 +2074,53 @@ fn rrf_score(rank: usize) -> f64 {
 
 fn merge_hybrid_results(
     keyword_hits: &[SearchHit],
-    embedding_hits: Vec<clawgallery_vdr::EmbeddingSearchHit>,
+    ranked_lists: Vec<Vec<clawgallery_vdr::EmbeddingSearchHit>>,
     candidates: &[SearchCandidate],
     limit: usize,
 ) -> Vec<SearchResult> {
+    let mut lists = vec![
+        keyword_hits
+            .iter()
+            .map(|hit| search_result_from_keyword_hit(hit, &candidates[hit.candidate_idx]))
+            .collect::<Vec<_>>(),
+    ];
+    lists.extend(ranked_lists.into_iter().map(|hits| {
+        hits.into_iter()
+            .map(search_result_from_embedding_hit)
+            .collect()
+    }));
+    fuse_rrf_results(lists, limit)
+}
+
+fn fuse_rrf_results(lists: Vec<Vec<SearchResult>>, limit: usize) -> Vec<SearchResult> {
     let mut by_path: HashMap<PathBuf, SearchResult> = HashMap::new();
-    for (rank, hit) in keyword_hits.iter().enumerate() {
-        let candidate = &candidates[hit.candidate_idx];
-        let mut result = search_result_from_keyword_hit(hit, candidate);
-        result.score = rrf_score(rank);
-        by_path.insert(result.path_raw.clone(), result);
-    }
-    for (rank, hit) in embedding_hits.into_iter().enumerate() {
-        let contribution = rrf_score(rank);
-        let path = hit.path.clone();
-        match by_path.get_mut(&path) {
-            Some(existing) => {
-                existing.score += contribution;
-                existing.source = HitSource::Hybrid;
-                if !existing.matched_field.contains(hit.matched_field) {
-                    existing.matched_field =
-                        format!("{},{}", existing.matched_field, hit.matched_field);
-                }
-                for atom in hit.matched_atoms {
-                    if !existing.matched_atoms.contains(&atom) {
-                        existing.matched_atoms.push(atom);
+    for list in lists {
+        for (rank, hit) in list.into_iter().enumerate() {
+            let contribution = rrf_score(rank);
+            let path = hit.path_raw.clone();
+            match by_path.get_mut(&path) {
+                Some(existing) => {
+                    existing.score += contribution;
+                    if existing.source != hit.source {
+                        existing.source = HitSource::Hybrid;
+                    }
+                    if !hit.matched_field.is_empty()
+                        && !existing.matched_field.contains(&hit.matched_field)
+                    {
+                        existing.matched_field =
+                            format!("{},{}", existing.matched_field, hit.matched_field);
+                    }
+                    for atom in hit.matched_atoms {
+                        if !existing.matched_atoms.contains(&atom) {
+                            existing.matched_atoms.push(atom);
+                        }
                     }
                 }
-            }
-            None => {
-                let mut result = search_result_from_embedding_hit(hit);
-                result.score = contribution;
-                by_path.insert(path, result);
+                None => {
+                    let mut result = hit;
+                    result.score = contribution;
+                    by_path.insert(path, result);
+                }
             }
         }
     }
@@ -2124,17 +2146,29 @@ fn cmd_search(paths: &AppPaths, args: SearchArgs) -> Result<()> {
     let query = nfc(&args.keywords.join(" "));
     let captions = latest_captions_by_path(paths)?;
     let images = latest_images(paths)?;
-    if matches!(args.mode, SearchMode::Embedding) {
-        let embedding_hits = vdr::embedding_search_hits(
-            paths,
-            &query,
-            args.limit,
-            args.embedding_url.as_deref(),
-            false,
-            images,
-            captions,
-        )?;
-        for hit in embedding_hits {
+    if matches!(args.mode, SearchMode::Embedding | SearchMode::Lexical) {
+        let hits = if matches!(args.mode, SearchMode::Lexical) {
+            vdr::lexical_search_hits(
+                paths,
+                &query,
+                args.limit,
+                args.embedding_url.as_deref(),
+                false,
+                images,
+                captions,
+            )?
+        } else {
+            vdr::embedding_search_hits(
+                paths,
+                &query,
+                args.limit,
+                args.embedding_url.as_deref(),
+                false,
+                images,
+                captions,
+            )?
+        };
+        for hit in hits {
             let result = search_result_from_embedding_hit(hit);
             if args.json {
                 print_json_search_result(&result)?;
@@ -2198,9 +2232,18 @@ fn cmd_search(paths: &AppPaths, args: SearchArgs) -> Result<()> {
             latest_images(paths)?,
             latest_captions_by_path(paths)?,
         )?;
+        let lexical_hits = vdr::lexical_search_hits(
+            paths,
+            &query,
+            keyword_limit,
+            args.embedding_url.as_deref(),
+            true,
+            latest_images(paths)?,
+            latest_captions_by_path(paths)?,
+        )?;
         let results = merge_hybrid_results(
             &hits.iter().take(keyword_limit).cloned().collect::<Vec<_>>(),
-            embedding_hits,
+            vec![lexical_hits, embedding_hits],
             &candidates,
             args.limit,
         );

--- a/src/vdr/backend.rs
+++ b/src/vdr/backend.rs
@@ -6,11 +6,14 @@ pub(super) const DEFAULT_MLX_DIMENSIONS: usize = 128;
 pub(super) const DEFAULT_MANAGED_HOST: &str = "127.0.0.1";
 const JINA_MLX_MODEL: &str = "jinaai/jina-embeddings-v5-omni-small-retrieval-mlx";
 const JINA_MLX_DIMENSIONS: usize = 1024;
+pub(super) const DEFAULT_VSPLADE_MODEL: &str = clawgallery_vdr::DEFAULT_VSPLADE_MODEL;
+pub(super) const DEFAULT_VSPLADE_DIMENSIONS: usize = clawgallery_vdr::DEFAULT_VSPLADE_DIMENSIONS;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub(crate) enum ServeBackend {
     Mlx,
     JinaMlx,
+    Vsplade,
 }
 
 pub(super) struct BackendConfig {
@@ -27,6 +30,9 @@ pub(super) fn resolve_backend(
     let backend = backend.unwrap_or_else(|| {
         if model == Some(JINA_MLX_MODEL) {
             ServeBackend::JinaMlx
+        } else if model.is_some_and(|value| value.contains("v-splade") || value.contains("vsplade"))
+        {
+            ServeBackend::Vsplade
         } else {
             ServeBackend::Mlx
         }
@@ -34,6 +40,7 @@ pub(super) fn resolve_backend(
     let (default_model, default_dimensions) = match backend {
         ServeBackend::Mlx => (DEFAULT_MLX_MODEL, DEFAULT_MLX_DIMENSIONS),
         ServeBackend::JinaMlx => (JINA_MLX_MODEL, JINA_MLX_DIMENSIONS),
+        ServeBackend::Vsplade => (DEFAULT_VSPLADE_MODEL, DEFAULT_VSPLADE_DIMENSIONS),
     };
     let model = model.unwrap_or(default_model);
     let dimensions = dimensions.unwrap_or(default_dimensions);

--- a/src/vdr/mod.rs
+++ b/src/vdr/mod.rs
@@ -1,11 +1,11 @@
 use crate::{AppPaths, CaptionRecord, ImageRecord};
-use anyhow::Result;
+use anyhow::{Result, bail};
 use clap::{Args, Subcommand};
 use clawgallery_vdr::{
     CaptionDocument, EmbeddingSearchHit, ImageDocument, SearchConfig, SyncConfig, SyncOutcome,
-    deactivate_image_vectors as deactivate_library_vectors, embedding_search,
-    pending_embedding_count, similar_image_groups as library_similar_image_groups,
-    status as library_status, sync,
+    VectorEncoding, deactivate_image_vectors as deactivate_library_vectors, embedding_search,
+    latest_dense_index_config, latest_sparse_index_config, lexical_search, pending_embedding_count,
+    similar_image_groups as library_similar_image_groups, status as library_status, sync,
 };
 use std::{collections::HashMap, env, path::PathBuf};
 
@@ -135,6 +135,7 @@ pub(crate) fn cmd_sync(paths: &AppPaths, args: VdrSyncArgs) -> Result<()> {
         embedding_url: args.embedding_url.clone(),
         max_retries: args.max_retries,
         prune: args.prune,
+        encoding: encoding_for(backend.backend),
     };
     let image_documents = image_documents(&images);
     let caption_documents = caption_documents_from_map(captions);
@@ -194,6 +195,13 @@ fn cmd_status(paths: &AppPaths, args: VdrStatusArgs) -> Result<()> {
     Ok(())
 }
 
+fn encoding_for(backend: ServeBackend) -> VectorEncoding {
+    match backend {
+        ServeBackend::Vsplade => VectorEncoding::Sparse,
+        ServeBackend::Mlx | ServeBackend::JinaMlx => VectorEncoding::Dense,
+    }
+}
+
 pub(crate) fn embedding_search_hits(
     paths: &AppPaths,
     query: &str,
@@ -203,14 +211,14 @@ pub(crate) fn embedding_search_hits(
     images: Vec<ImageRecord>,
     captions: HashMap<PathBuf, CaptionRecord>,
 ) -> Result<Vec<EmbeddingSearchHit>> {
-    let status = library_status(&paths.vdr_db, images.len())?;
-    if status.active_vectors == 0 && skip_empty_index {
+    let index = latest_dense_index_config(&paths.vdr_db)?;
+    if index.is_none() && skip_empty_index {
         return Ok(Vec::new());
     }
-    let model = status
-        .model
-        .unwrap_or_else(|| DEFAULT_MLX_MODEL.to_string());
-    let dimensions = status.dimensions.unwrap_or(DEFAULT_MLX_DIMENSIONS);
+    let (model, dimensions) = match index {
+        Some(index) => (index.model, index.dimensions),
+        None => (DEFAULT_MLX_MODEL.to_string(), DEFAULT_MLX_DIMENSIONS),
+    };
     let backend = resolve_backend(None, Some(&model), Some(dimensions))?;
     let env_embedding_url = env::var("CLAWGALLERY_VDR_EMBEDDING_URL").ok();
     let managed_server = if embedding_url.is_none() && env_embedding_url.is_none() {
@@ -240,6 +248,61 @@ pub(crate) fn embedding_search_hits(
             db_path: paths.vdr_db.clone(),
             model: Some(model),
             dimensions: Some(dimensions),
+            embedding_url,
+            limit,
+        },
+        query,
+        image_documents(&images),
+        caption_documents_from_map(captions),
+    )
+}
+
+pub(crate) fn lexical_search_hits(
+    paths: &AppPaths,
+    query: &str,
+    limit: usize,
+    embedding_url: Option<&str>,
+    skip_empty_index: bool,
+    images: Vec<ImageRecord>,
+    captions: HashMap<PathBuf, CaptionRecord>,
+) -> Result<Vec<EmbeddingSearchHit>> {
+    let index = latest_sparse_index_config(&paths.vdr_db)?;
+    if index.is_none() {
+        if skip_empty_index {
+            return Ok(Vec::new());
+        }
+        bail!("no V-SPLADE lexical index; run `clawgallery vdr sync --backend vsplade`");
+    }
+    let index = index.expect("sparse index checked");
+    let backend = resolve_backend(None, Some(&index.model), Some(index.dimensions))?;
+    let env_embedding_url = env::var("CLAWGALLERY_VDR_EMBEDDING_URL").ok();
+    let managed_server = if embedding_url.is_none() && env_embedding_url.is_none() {
+        Some(serve::ManagedServer::start_quiet(&serve::ServeArgs {
+            backend: backend.backend,
+            host: DEFAULT_MANAGED_HOST.to_string(),
+            port: 0,
+            model: index.model.clone(),
+            dimensions: index.dimensions,
+            device: "auto".to_string(),
+            python: None,
+            allow_remote: false,
+        })?)
+    } else {
+        None
+    };
+    let embedding_url = embedding_url
+        .map(str::to_string)
+        .or(env_embedding_url)
+        .or_else(|| {
+            managed_server
+                .as_ref()
+                .map(|server| server.url().to_string())
+        });
+    lexical_search(
+        &SearchConfig {
+            db_path: paths.vdr_db.clone(),
+            model: Some(index.model),
+            dimensions: Some(index.dimensions),
             embedding_url,
             limit,
         },

--- a/src/vdr/serve.rs
+++ b/src/vdr/serve.rs
@@ -12,6 +12,7 @@ use std::{
 
 const MLX_SERVER: &str = include_str!("../../scripts/mlx_embeddings_server.py");
 const JINA_MLX_SERVER: &str = include_str!("../../scripts/jina_mlx_embeddings_server.py");
+const VSPLADE_SERVER: &str = include_str!("../../scripts/vsplade_server.py");
 const MANAGED_STARTUP_TIMEOUT: Duration = Duration::from_secs(20 * 60);
 
 impl ServeBackend {
@@ -19,6 +20,7 @@ impl ServeBackend {
         match self {
             Self::Mlx => "mlx",
             Self::JinaMlx => "jina-mlx",
+            Self::Vsplade => "vsplade",
         }
     }
 
@@ -26,6 +28,7 @@ impl ServeBackend {
         match self {
             Self::Mlx => MLX_SERVER,
             Self::JinaMlx => JINA_MLX_SERVER,
+            Self::Vsplade => VSPLADE_SERVER,
         }
     }
 }

--- a/tests/vdr_cli.rs
+++ b/tests/vdr_cli.rs
@@ -839,3 +839,214 @@ fn default_search_uses_hybrid_keyword_and_embedding_results() {
         "default search should include embedding result, got: {stdout}"
     );
 }
+
+#[test]
+fn lexical_search_ranks_vsplade_sparse_overlap() {
+    let server = FakeEmbeddingServer::start();
+    let temp = tempfile::tempdir().expect("tempdir");
+    let config = temp.path().join("state");
+    let images = temp.path().join("images");
+    fs::create_dir_all(&images).expect("create images");
+    fs::write(images.join("dog.png"), b"dog image bytes").expect("write dog image");
+    fs::write(images.join("login.png"), b"login image bytes").expect("write login image");
+    assert_success(run(&config, &["init"], server.url()));
+    assert_success(run(
+        &config,
+        &["bootstrap", "--path", images.to_str().expect("utf8")],
+        server.url(),
+    ));
+    let (dog_id, dog_path) = image_id_for(&config, "dog.png");
+    let (login_id, login_path) = image_id_for(&config, "login.png");
+    write_caption(&config, &dog_id, &dog_path, "Animal Photo", "puppy playing");
+    write_caption(&config, &login_id, &login_path, "Settings", "password form");
+    let synced = assert_success(run(
+        &config,
+        &[
+            "vdr",
+            "sync",
+            "--backend",
+            "vsplade",
+            "--model",
+            "vsplade-test",
+            "--dimensions",
+            "8",
+        ],
+        server.url(),
+    ));
+    assert!(
+        synced.contains("indexed 2"),
+        "lexical sync should index images only, got: {synced}"
+    );
+
+    let stdout = assert_success(run(
+        &config,
+        &["search", "--mode", "lexical", "dog", "--json"],
+        server.url(),
+    ));
+    let rows: Vec<serde_json::Value> = stdout
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("json result"))
+        .collect();
+    assert!(
+        !rows.is_empty(),
+        "lexical search should return hits, got: {stdout}"
+    );
+    assert!(
+        rows[0]["path"].as_str().expect("path").ends_with("dog.png"),
+        "dog query should rank dog.png first, got: {stdout}"
+    );
+    assert_eq!(rows[0]["source"], "lexical");
+    assert_eq!(rows[0]["matched_field"], "lexical_image");
+}
+
+#[test]
+fn dense_and_sparse_indexes_coexist_after_separate_syncs() {
+    let server = FakeEmbeddingServer::start();
+    let temp = tempfile::tempdir().expect("tempdir");
+    let config = temp.path().join("state");
+    let images = temp.path().join("images");
+    fs::create_dir_all(&images).expect("create images");
+    fs::write(images.join("dog.png"), b"dog image bytes").expect("write dog image");
+    assert_success(run(&config, &["init"], server.url()));
+    assert_success(run(
+        &config,
+        &["bootstrap", "--path", images.to_str().expect("utf8")],
+        server.url(),
+    ));
+    let (dog_id, dog_path) = image_id_for(&config, "dog.png");
+    write_caption(&config, &dog_id, &dog_path, "Animal Photo", "puppy playing");
+
+    assert_success(run(
+        &config,
+        &["vdr", "sync", "--model", "dense-test", "--dimensions", "4"],
+        server.url(),
+    ));
+    assert_success(run(
+        &config,
+        &[
+            "vdr",
+            "sync",
+            "--backend",
+            "vsplade",
+            "--model",
+            "vsplade-test",
+            "--dimensions",
+            "8",
+        ],
+        server.url(),
+    ));
+
+    let status: serde_json::Value = serde_json::from_str(&assert_success(run(
+        &config,
+        &["vdr", "status", "--json"],
+        server.url(),
+    )))
+    .expect("status json");
+    assert_eq!(
+        status["active_vectors"], 3,
+        "dense image+caption plus sparse image must stay active, got: {status}"
+    );
+
+    let embedding = assert_success(run(
+        &config,
+        &["search", "--mode", "embedding", "dog", "--json"],
+        server.url(),
+    ));
+    let lexical = assert_success(run(
+        &config,
+        &["search", "--mode", "lexical", "dog", "--json"],
+        server.url(),
+    ));
+    let embedding_row: serde_json::Value =
+        serde_json::from_str(embedding.lines().next().expect("embedding hit")).unwrap();
+    let lexical_row: serde_json::Value =
+        serde_json::from_str(lexical.lines().next().expect("lexical hit")).unwrap();
+    assert_eq!(embedding_row["source"], "embedding");
+    assert_eq!(lexical_row["source"], "lexical");
+}
+
+#[test]
+fn hybrid_search_rrf_includes_lexical_hits() {
+    let server = FakeEmbeddingServer::start();
+    let temp = tempfile::tempdir().expect("tempdir");
+    let config = temp.path().join("state");
+    let images = temp.path().join("images");
+    fs::create_dir_all(&images).expect("create images");
+    fs::write(images.join("login.png"), b"login image bytes").expect("write login image");
+    fs::write(images.join("dog.png"), b"dog image bytes").expect("write dog image");
+    assert_success(run(&config, &["init"], server.url()));
+    assert_success(run(
+        &config,
+        &["bootstrap", "--path", images.to_str().expect("utf8")],
+        server.url(),
+    ));
+    let (login_id, login_path) = image_id_for(&config, "login.png");
+    let (dog_id, dog_path) = image_id_for(&config, "dog.png");
+    write_caption(
+        &config,
+        &login_id,
+        &login_path,
+        "Login Dialog",
+        "settings screen",
+    );
+    write_caption(&config, &dog_id, &dog_path, "Animal Photo", "outside");
+    assert_success(run(
+        &config,
+        &[
+            "vdr",
+            "sync",
+            "--backend",
+            "vsplade",
+            "--model",
+            "vsplade-test",
+            "--dimensions",
+            "8",
+        ],
+        server.url(),
+    ));
+
+    let stdout = assert_success(run(
+        &config,
+        &["search", "dog", "--json", "--limit", "5"],
+        server.url(),
+    ));
+    let rows: Vec<serde_json::Value> = stdout
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("json result"))
+        .collect();
+    assert!(
+        rows.iter().any(|row| {
+            row["path"].as_str().expect("path").ends_with("dog.png")
+                && (row["source"] == "lexical" || row["source"] == "hybrid")
+        }),
+        "hybrid RRF should surface the V-SPLADE dog hit, got: {stdout}"
+    );
+}
+
+#[test]
+fn lexical_search_without_index_explains_how_to_build_it() {
+    let server = FakeEmbeddingServer::start();
+    let temp = tempfile::tempdir().expect("tempdir");
+    let config = temp.path().join("state");
+    let images = temp.path().join("images");
+    fs::create_dir_all(&images).expect("create images");
+    fs::write(images.join("dog.png"), b"dog image bytes").expect("write dog image");
+    assert_success(run(&config, &["init"], server.url()));
+    assert_success(run(
+        &config,
+        &["bootstrap", "--path", images.to_str().expect("utf8")],
+        server.url(),
+    ));
+
+    let output = run(
+        &config,
+        &["search", "--mode", "lexical", "dog", "--json"],
+        server.url(),
+    );
+    assert!(!output.status.success(), "missing lexical index must fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("vdr sync --backend vsplade"),
+        "got: {stderr}"
+    );
+}

--- a/tests/vdr_serve_cli.rs
+++ b/tests/vdr_serve_cli.rs
@@ -48,6 +48,19 @@ fn vdr_serve_help_lists_jina_mlx_backend() {
 }
 
 #[test]
+fn vdr_serve_help_lists_vsplade_backend() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let output = Command::new(clawgallery_bin())
+        .env("CLAWGALLERY_CONFIG_DIR", temp.path().join("state"))
+        .args(["vdr", "serve", "--help"])
+        .output()
+        .expect("clawgallery command should run");
+    assert!(output.status.success(), "serve help should succeed");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("vsplade"), "got: {stdout}");
+}
+
+#[test]
 fn vdr_serve_jina_mlx_rejects_incompatible_dimensions() {
     // Given: the Jina MLX backend with a ColQwen-sized vector request.
     let temp = tempfile::tempdir().expect("tempdir");

--- a/tests/vdr_support/mod.rs
+++ b/tests/vdr_support/mod.rs
@@ -194,18 +194,39 @@ fn handle_request(
     let inputs = request["inputs"].as_array().expect("inputs array");
     let model = request["model"].as_str().unwrap_or("test-model");
     let response_model = response_model.unwrap_or(model);
-    let response = if multivector {
-        let embeddings: Vec<_> = inputs.iter().map(multivector_for).collect();
+    let dimensions = request["dimensions"].as_u64().unwrap_or(4) as usize;
+    let sparse = request.get("format").and_then(|value| value.as_str()) == Some("sparse")
+        || model.contains("vsplade")
+        || model.contains("v-splade");
+    let response = if sparse {
+        let embeddings: Vec<_> = inputs
+            .iter()
+            .map(|input| sparse_for(input, dimensions))
+            .collect();
         serde_json::json!({
             "model": response_model,
-            "dimensions": 4,
+            "dimensions": dimensions,
+            "format": "sparse",
+            "embeddings": embeddings
+        })
+    } else if multivector {
+        let embeddings: Vec<_> = inputs
+            .iter()
+            .map(|input| multivector_for(input, dimensions))
+            .collect();
+        serde_json::json!({
+            "model": response_model,
+            "dimensions": dimensions,
             "embeddings": embeddings
         })
     } else {
-        let embeddings: Vec<_> = inputs.iter().map(embedding_for).collect();
+        let embeddings: Vec<_> = inputs
+            .iter()
+            .map(|input| embedding_for(input, dimensions))
+            .collect();
         serde_json::json!({
             "model": response_model,
-            "dimensions": 4,
+            "dimensions": dimensions,
             "embeddings": embeddings
         })
     };
@@ -218,9 +239,14 @@ fn handle_request(
     stream.write_all(reply.as_bytes()).expect("write response");
 }
 
-fn embedding_for(input: &serde_json::Value) -> Vec<f32> {
+fn pad_dims(mut row: Vec<f32>, dimensions: usize) -> Vec<f32> {
+    row.resize(dimensions.max(1), 0.0);
+    row
+}
+
+fn embedding_for(input: &serde_json::Value, dimensions: usize) -> Vec<f32> {
     let haystack = input["value"].as_str().unwrap_or_default().to_lowercase();
-    if haystack.contains("dog") || haystack.contains("puppy") {
+    let row = if haystack.contains("dog") || haystack.contains("puppy") {
         vec![1.0, 0.0, 0.0, 0.0]
     } else if haystack.contains("cat") || haystack.contains("kitten") {
         vec![0.0, 1.0, 0.0, 0.0]
@@ -228,18 +254,34 @@ fn embedding_for(input: &serde_json::Value) -> Vec<f32> {
         vec![0.0, 0.0, 1.0, 0.0]
     } else {
         vec![0.0, 0.0, 0.0, 1.0]
-    }
+    };
+    pad_dims(row, dimensions)
+}
+
+fn sparse_for(input: &serde_json::Value, dimensions: usize) -> serde_json::Value {
+    let haystack = input["value"].as_str().unwrap_or_default().to_lowercase();
+    let (index, value) = if haystack.contains("dog") || haystack.contains("puppy") {
+        (1_u32, 2.0_f32)
+    } else if haystack.contains("cat") || haystack.contains("kitten") {
+        (2, 2.0)
+    } else if haystack.contains("login") {
+        (3, 2.0)
+    } else {
+        (0, 0.1)
+    };
+    let index = index.min(dimensions.saturating_sub(1) as u32);
+    serde_json::json!({"indices": [index], "values": [value]})
 }
 
 /// Emits one token-level vector per word so MaxSim has multiple rows to
 /// reduce over, mimicking a late-interaction model.
-fn multivector_for(input: &serde_json::Value) -> Vec<Vec<f32>> {
+fn multivector_for(input: &serde_json::Value, dimensions: usize) -> Vec<Vec<f32>> {
     let haystack = input["value"].as_str().unwrap_or_default().to_lowercase();
     let mut rows: Vec<Vec<f32>> = haystack
         .split(|c: char| !c.is_ascii_alphanumeric())
         .filter(|word| !word.is_empty())
         .map(|word| {
-            if word.contains("dog") || word.contains("puppy") {
+            let row = if word.contains("dog") || word.contains("puppy") {
                 vec![1.0, 0.0, 0.0, 0.0]
             } else if word.contains("cat") || word.contains("kitten") {
                 vec![0.0, 1.0, 0.0, 0.0]
@@ -247,11 +289,12 @@ fn multivector_for(input: &serde_json::Value) -> Vec<Vec<f32>> {
                 vec![0.0, 0.0, 1.0, 0.0]
             } else {
                 vec![0.0, 0.0, 0.0, 1.0]
-            }
+            };
+            pad_dims(row, dimensions)
         })
         .collect();
     if rows.is_empty() {
-        rows.push(vec![0.0, 0.0, 0.0, 1.0]);
+        rows.push(pad_dims(vec![0.0, 0.0, 0.0, 1.0], dimensions));
     }
     rows
 }

--- a/tests/vsplade_live_cli.rs
+++ b/tests/vsplade_live_cli.rs
@@ -1,0 +1,261 @@
+use std::{
+    env, fs,
+    io::Write,
+    path::{Path, PathBuf},
+    process::{Command, Output, Stdio},
+    thread,
+    time::{Duration, Instant},
+};
+
+fn clawgallery_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_clawgallery"))
+}
+
+fn python() -> PathBuf {
+    env::var_os("CLAWGALLERY_PYTHON")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("/Users/jeffrey/Projects/SPLADE-mlx/.venv/bin/python"))
+}
+
+fn run(config: &Path, args: &[&str], extra_env: &[(&str, &str)]) -> Output {
+    let mut command = Command::new(clawgallery_bin());
+    command
+        .env("CLAWGALLERY_CONFIG_DIR", config)
+        .env_remove("CLAWGALLERY_VDR_EMBEDDING_URL")
+        .env_remove("OPENAI_API_KEY")
+        .env("CODEX_HOME", config.join("codex-home"))
+        .args(args);
+    for (key, value) in extra_env {
+        command.env(key, value);
+    }
+    command.output().expect("clawgallery command should run")
+}
+
+fn assert_success(output: Output) -> String {
+    if !output.status.success() {
+        panic!(
+            "command failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    String::from_utf8_lossy(&output.stdout).to_string()
+}
+
+fn write_text_png(python: &Path, path: &Path, text: &str) {
+    let script = format!(
+        r#"
+from PIL import Image, ImageDraw, ImageFont
+img = Image.new("RGB", (768, 512), "white")
+draw = ImageDraw.Draw(img)
+font = ImageFont.load_default()
+draw.text((40, 200), {text:?}, fill="black", font=font)
+img.save({path:?})
+"#
+    );
+    let status = Command::new(python)
+        .arg("-c")
+        .arg(script)
+        .status()
+        .expect("python png renderer");
+    assert!(status.success(), "failed to render {}", path.display());
+}
+
+fn wait_for_embed(url: &str, model: &str, dimensions: usize, timeout: Duration) {
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .expect("http client");
+    let endpoint = format!("{url}/embed");
+    let deadline = Instant::now() + timeout;
+    loop {
+        if Instant::now() >= deadline {
+            panic!("V-SPLADE server at {url} did not become reachable");
+        }
+        let response = client
+            .post(&endpoint)
+            .json(&serde_json::json!({
+                "model": model,
+                "dimensions": dimensions,
+                "format": "sparse",
+                "inputs": []
+            }))
+            .send();
+        if matches!(response, Ok(resp) if resp.status().is_success()) {
+            return;
+        }
+        thread::sleep(Duration::from_millis(250));
+    }
+}
+
+#[test]
+#[ignore = "requires local SPLADE-mlx venv and V-SPLADE weights"]
+fn live_vsplade_lexical_and_hybrid_search() {
+    let python = python();
+    assert!(
+        python.exists(),
+        "CLAWGALLERY_PYTHON or SPLADE-mlx venv python is required"
+    );
+    let temp = tempfile::tempdir().expect("tempdir");
+    let config = temp.path().join("state");
+    let images = temp.path().join("images");
+    fs::create_dir_all(&images).expect("create images");
+    let invoice = images.join("invoice.png");
+    let beach = images.join("beach.png");
+    write_text_png(&python, &invoice, "INVOICE TOTAL REVENUE 2023");
+    write_text_png(&python, &beach, "SUNSET BEACH PHOTO");
+
+    let empty = run(&config, &["init"], &[]);
+    assert_success(empty);
+    assert_success(run(
+        &config,
+        &["bootstrap", "--path", images.to_str().expect("utf8")],
+        &[],
+    ));
+
+    let mut captions = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(config.join("captions.jsonl"))
+        .expect("captions");
+    let images_jsonl = fs::read_to_string(config.join("images.jsonl")).expect("images");
+    for line in images_jsonl.lines().filter(|line| !line.trim().is_empty()) {
+        let record: serde_json::Value = serde_json::from_str(line).expect("image");
+        let path = record["path"].as_str().expect("path");
+        let title = if path.ends_with("invoice.png") {
+            "Receipt Scan"
+        } else {
+            "Holiday Snapshot"
+        };
+        writeln!(
+            captions,
+            "{}",
+            serde_json::json!({
+                "image_id": record["id"],
+                "path": path,
+                "title": title,
+                "description": title,
+                "model": "test",
+                "provider": "test",
+                "created_at": "2026-08-19T00:00:00Z",
+                "filename_meaningful": false
+            })
+        )
+        .expect("caption");
+    }
+
+    let model = "NomaDamas/v-splade-efficient-mlx";
+    let dimensions = 50368_usize;
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().expect("addr").port();
+    drop(listener);
+    let url = format!("http://127.0.0.1:{port}");
+    let script = include_str!("../scripts/vsplade_server.py");
+    let mut child = Command::new(&python)
+        .arg("-c")
+        .arg(script)
+        .arg("--host")
+        .arg("127.0.0.1")
+        .arg("--port")
+        .arg(port.to_string())
+        .arg("--model")
+        .arg(model)
+        .arg("--dimensions")
+        .arg(dimensions.to_string())
+        .stdout(Stdio::null())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("start vsplade server");
+    wait_for_embed(&url, model, dimensions, Duration::from_secs(20 * 60));
+
+    let env = [("CLAWGALLERY_PYTHON", python.to_str().expect("utf8"))];
+    let synced = assert_success(run(
+        &config,
+        &[
+            "vdr",
+            "sync",
+            "--backend",
+            "vsplade",
+            "--model",
+            model,
+            "--dimensions",
+            &dimensions.to_string(),
+            "--embedding-url",
+            &url,
+            "--no-auto-start",
+        ],
+        &env,
+    ));
+    assert!(
+        synced.contains("indexed 2"),
+        "live sync should index both images, got: {synced}"
+    );
+
+    let lexical = assert_success(run(
+        &config,
+        &[
+            "search",
+            "--mode",
+            "lexical",
+            "--embedding-url",
+            &url,
+            "invoice total revenue",
+            "--json",
+            "--limit",
+            "2",
+        ],
+        &env,
+    ));
+    let lexical_rows: Vec<serde_json::Value> = lexical
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("json"))
+        .collect();
+    assert!(
+        lexical_rows[0]["path"]
+            .as_str()
+            .expect("path")
+            .ends_with("invoice.png"),
+        "live lexical search should rank the invoice screenshot first, got: {lexical}"
+    );
+    assert_eq!(lexical_rows[0]["source"], "lexical");
+    assert!(
+        lexical_rows[0]["score"].as_f64().expect("score")
+            > lexical_rows
+                .get(1)
+                .and_then(|row| row["score"].as_f64())
+                .unwrap_or(0.0),
+        "invoice should outscore beach, got: {lexical}"
+    );
+
+    let hybrid = assert_success(run(
+        &config,
+        &[
+            "search",
+            "--mode",
+            "hybrid",
+            "--embedding-url",
+            &url,
+            "invoice total revenue",
+            "--json",
+            "--limit",
+            "5",
+        ],
+        &env,
+    ));
+    let hybrid_rows: Vec<serde_json::Value> = hybrid
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("json"))
+        .collect();
+    assert!(
+        hybrid_rows.iter().any(|row| {
+            row["path"].as_str().expect("path").ends_with("invoice.png")
+                && (row["source"] == "lexical"
+                    || row["source"] == "hybrid"
+                    || row["source"] == "fuzzy")
+        }),
+        "hybrid RRF should keep the invoice hit, got: {hybrid}"
+    );
+
+    let _ = child.kill();
+    let _ = child.wait();
+}


### PR DESCRIPTION
## Summary
- Add V-SPLADE (`NomaDamas/v-splade-efficient-mlx`) as `--mode lexical`: page images encode to sparse `{indices,values}` postings; queries use the inference-free lookup.
- Keep dense VDR rows active when the sparse index is synced (`vdr sync --backend vsplade`).
- Default hybrid search Reciprocal-Rank-Fuses keyword + lexical + embedding lists (empty lists skipped).

## Test plan
- [x] `cargo test --workspace --all-features` (live test ignored in CI)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] Fake-server CLI: lexical ranking, dense+sparse coexistence, hybrid RRF, missing-index error
- [x] Live e2e: `cargo test --test vsplade_live_cli -- --ignored live_vsplade_lexical_and_hybrid_search` against cached V-SPLADE MLX weights