### PR TITLE
fix(vdr): diagnose missing V-SPLADE runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,13 +166,21 @@ clawgallery search --mode lexical "invoice total"
 
 The managed V-SPLADE server requires `splade_mlx` and its MLX dependencies in the
 Python interpreter used to start it. If `--python` and `CLAWGALLERY_PYTHON` are
-not set, ClawGallery uses `python3` but checks the runtime before starting the
-server and prints the exact interpreter and remediation when the dependency is
-missing. For example:
+not set, ClawGallery first uses an active `VIRTUAL_ENV` interpreter and then the
+platform default (`python3` on macOS/Linux, `python` on Windows). It checks the
+runtime before starting the server and prints the exact interpreter and
+remediation when the dependency is missing. For example:
 
 ```bash
 python3 -m pip install git+https://github.com/NomaDamas/SPLADE-mlx.git
 CLAWGALLERY_PYTHON=python3 clawgallery vdr sync --backend vsplade
+```
+
+On Windows, install the same package into the active environment and use:
+
+```powershell
+python -m pip install git+https://github.com/NomaDamas/SPLADE-mlx.git
+clawgallery vdr sync --backend vsplade
 ```
 
 Default model: `NomaDamas/v-splade-efficient-mlx` (Apache-2.0, 50368-dim vocabulary). Sparse postings are stored in `vdr.sqlite3` next to dense VDR rows and do not deactivate them.

--- a/README.md
+++ b/README.md
@@ -164,6 +164,17 @@ CLAWGALLERY_PYTHON=/path/to/splade-mlx/.venv/bin/python \
 clawgallery search --mode lexical "invoice total"
 ```
 
+The managed V-SPLADE server requires `splade_mlx` and its MLX dependencies in the
+Python interpreter used to start it. If `--python` and `CLAWGALLERY_PYTHON` are
+not set, ClawGallery uses `python3` but checks the runtime before starting the
+server and prints the exact interpreter and remediation when the dependency is
+missing. For example:
+
+```bash
+python3 -m pip install git+https://github.com/NomaDamas/SPLADE-mlx.git
+CLAWGALLERY_PYTHON=python3 clawgallery vdr sync --backend vsplade
+```
+
 Default model: `NomaDamas/v-splade-efficient-mlx` (Apache-2.0, 50368-dim vocabulary). Sparse postings are stored in `vdr.sqlite3` next to dense VDR rows and do not deactivate them.
 
 ## Visual search (VDR)

--- a/skills/clawgallery/SKILL.md
+++ b/skills/clawgallery/SKILL.md
@@ -78,12 +78,44 @@ Search atoms follow fzf-like rules for the keyword side: whitespace means AND, `
 Use the MLX V-SPLADE runtime from [SPLADE-mlx](https://github.com/NomaDamas/SPLADE-mlx) for sparse visual-lexical retrieval. Point `CLAWGALLERY_PYTHON` at an environment with `splade-mlx`, `mlx`, `transformers`, `numpy`, and `pillow`:
 
 ```bash
-CLAWGALLERY_PYTHON=/path/to/splade-mlx/.venv/bin/python \
-  clawgallery vdr sync --backend vsplade
+export CLAWGALLERY_PYTHON=/path/to/splade-mlx/.venv/bin/python
+clawgallery vdr sync --backend vsplade
 clawgallery search --mode lexical "invoice total" --json
 ```
 
 Default model `NomaDamas/v-splade-efficient-mlx`, dimensions `50368`. The index stores sparse `{indices,values}` postings and can coexist with a dense VDR index. Hybrid search fuses keyword + lexical + embedding ranks with RRF (`k=60`).
+
+Keep `CLAWGALLERY_PYTHON` exported for both `vdr sync` and every later
+`search` command. Managed servers are started per command, so setting the
+variable only on the sync command does not configure the subsequent search.
+ClawGallery checks the selected interpreter for `splade_mlx` before starting
+the server; if it is missing, install the runtime into that same environment
+or pass its interpreter explicitly with `--python`:
+
+```bash
+python3 -m pip install git+https://github.com/NomaDamas/SPLADE-mlx.git
+export CLAWGALLERY_PYTHON="$(pwd)/.venv/bin/python"
+clawgallery vdr sync --backend vsplade
+clawgallery search --mode lexical "invoice total" --json
+```
+
+With an activated virtual environment, ClawGallery also uses its
+`bin/python` interpreter on macOS/Linux or `Scripts/python.exe` on Windows.
+Without `CLAWGALLERY_PYTHON` or an active environment, it falls back to
+`python3` on macOS/Linux and `python` on Windows. This fallback does not
+install dependencies automatically. For a one-off command, use:
+
+```bash
+clawgallery vdr sync --backend vsplade --python /path/to/splade-mlx/.venv/bin/python
+CLAWGALLERY_PYTHON=/path/to/splade-mlx/.venv/bin/python \
+  clawgallery search --mode lexical "invoice total" --json
+```
+
+The managed server downloads and caches model weights on first use, then is
+terminated automatically when the command exits. Use `--embedding-url` to
+reuse an already-running compatible server, or `--no-auto-start` when an
+external server is required. A missing Python dependency is a setup error,
+not an index corruption error; the existing SQLite index remains intact.
 
 ## VDR model setup
 

--- a/skills/clawgallery/references/usage.md
+++ b/skills/clawgallery/references/usage.md
@@ -12,6 +12,7 @@
 - Search captions/paths only: `clawgallery search --mode keyword "<query>" --json --limit 5`
 - Search VDR embeddings only: `clawgallery search --mode embedding "<query>" --json --limit 5`
 - Sync VDR embeddings: `clawgallery vdr sync`
+- Sync V-SPLADE lexical embeddings: `CLAWGALLERY_PYTHON=/path/to/splade-mlx/.venv/bin/python clawgallery vdr sync --backend vsplade`
 - Check VDR state: `clawgallery vdr status --json`
 - Full enrich + retrieve: `clawgallery caption --missing && clawgallery vdr sync --prune && clawgallery search "<query>" --json`
 - Report exact duplicates: `clawgallery dedup --exact --json`
@@ -30,3 +31,34 @@ test -d ~/Picutres/screenshots && clawgallery folder add ~/Picutres/screenshots
 clawgallery bootstrap
 clawgallery search "<observed visual query>" --json --limit 5
 ```
+
+## V-SPLADE runtime notes
+
+V-SPLADE image indexing and lexical query embedding use the packaged managed
+Python server. It is started and stopped automatically for each command; no
+manual daemon step is required. Set the Python interpreter in the shell
+environment before both indexing and searching:
+
+```bash
+export CLAWGALLERY_PYTHON=/path/to/splade-mlx/.venv/bin/python
+clawgallery vdr sync --backend vsplade
+clawgallery search --mode lexical "invoice total" --json
+```
+
+Do not set `CLAWGALLERY_PYTHON` only before `vdr sync`: a later `search`
+invocation is a new process and otherwise falls back to `python3` (or
+`python` on Windows). The selected interpreter must import `splade_mlx`.
+Install the runtime in that environment, or use `--python <path>` for sync
+and keep `CLAWGALLERY_PYTHON` set for search:
+
+```bash
+python3 -m pip install git+https://github.com/NomaDamas/SPLADE-mlx.git
+export CLAWGALLERY_PYTHON=/path/to/splade-mlx/.venv/bin/python
+```
+
+An activated `VIRTUAL_ENV` is detected automatically using `bin/python` on
+macOS/Linux and `Scripts/python.exe` on Windows. If no suitable environment
+is configured, ClawGallery reports the selected interpreter and a remediation
+command before spawning the server. It does not install Python packages
+automatically. Use `--embedding-url` to connect to a compatible long-running
+server or `--no-auto-start` when deliberately managing the endpoint yourself.

--- a/src/vdr/serve.rs
+++ b/src/vdr/serve.rs
@@ -86,6 +86,7 @@ fn start_managed_server(args: &ServeArgs, announce: bool) -> Result<ManagedServe
 
 fn run_python_server(args: &ServeArgs) -> Result<()> {
     let python = resolve_python(args.python.as_ref());
+    check_python_runtime(args.backend, &python)?;
     let mut command = python_command(args, &python, args.port);
     let status = command
         .stdin(Stdio::inherit())
@@ -198,10 +199,35 @@ fn wait_until_embed_reachable(
 
 fn resolve_python(explicit: Option<&PathBuf>) -> PathBuf {
     explicit.cloned().unwrap_or_else(|| {
-        env::var_os("CLAWGALLERY_PYTHON")
-            .map(PathBuf::from)
-            .unwrap_or_else(|| PathBuf::from("python3"))
+        if let Some(python) = env::var_os("CLAWGALLERY_PYTHON") {
+            return PathBuf::from(python);
+        }
+        if let Some(virtual_env) = env::var_os("VIRTUAL_ENV")
+            && let Some(python) = virtual_env_python(PathBuf::from(virtual_env))
+        {
+            return python;
+        }
+        default_python()
     })
+}
+
+fn virtual_env_python(virtual_env: PathBuf) -> Option<PathBuf> {
+    let python = if cfg!(windows) {
+        virtual_env.join("Scripts").join("python.exe")
+    } else {
+        virtual_env.join("bin").join("python")
+    };
+    python.is_file().then_some(python)
+}
+
+#[cfg(windows)]
+fn default_python() -> PathBuf {
+    PathBuf::from("python")
+}
+
+#[cfg(not(windows))]
+fn default_python() -> PathBuf {
+    PathBuf::from("python3")
 }
 
 fn check_python_runtime(backend: ServeBackend, python: &PathBuf) -> Result<()> {
@@ -250,4 +276,32 @@ fn is_loopback_host(host: &str) -> bool {
     host.parse::<IpAddr>()
         .map(|address| address.is_loopback())
         .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{default_python, virtual_env_python};
+    use std::fs;
+
+    #[test]
+    fn virtual_env_python_uses_platform_layout() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let python = if cfg!(windows) {
+            temp.path().join("Scripts").join("python.exe")
+        } else {
+            temp.path().join("bin").join("python")
+        };
+        fs::create_dir_all(python.parent().expect("python parent")).expect("python directory");
+        fs::write(&python, b"").expect("python file");
+
+        assert_eq!(virtual_env_python(temp.path().to_path_buf()), Some(python));
+    }
+
+    #[test]
+    fn default_python_uses_platform_name() {
+        assert_eq!(
+            default_python().file_name().expect("python filename"),
+            if cfg!(windows) { "python" } else { "python3" }
+        );
+    }
 }

--- a/src/vdr/serve.rs
+++ b/src/vdr/serve.rs
@@ -104,6 +104,7 @@ fn run_python_server(args: &ServeArgs) -> Result<()> {
 
 fn start_python_server(args: &ServeArgs, announce: bool) -> Result<ManagedServer> {
     let python = resolve_python(args.python.as_ref());
+    check_python_runtime(args.backend, &python)?;
     let port = if args.port == 0 {
         choose_available_port(&args.host)?
     } else {
@@ -201,6 +202,36 @@ fn resolve_python(explicit: Option<&PathBuf>) -> PathBuf {
             .map(PathBuf::from)
             .unwrap_or_else(|| PathBuf::from("python3"))
     })
+}
+
+fn check_python_runtime(backend: ServeBackend, python: &PathBuf) -> Result<()> {
+    if backend != ServeBackend::Vsplade
+        || env::var_os("CLAWGALLERY_VDR_VSPLADE_FAKE").is_some_and(|value| value == "1")
+    {
+        return Ok(());
+    }
+    let output = Command::new(python)
+        .args(["-c", "import splade_mlx"])
+        .output()
+        .with_context(|| {
+            format!(
+                "failed to inspect V-SPLADE Python runtime {}",
+                python.display()
+            )
+        })?;
+    if output.status.success() {
+        return Ok(());
+    }
+    bail!(
+        "V-SPLADE runtime is unavailable in {}: could not import splade_mlx. \
+Install SPLADE-mlx in this environment, then retry with \
+--python {} or CLAWGALLERY_PYTHON={}. \
+Example: {} -m pip install git+https://github.com/NomaDamas/SPLADE-mlx.git",
+        python.display(),
+        python.display(),
+        python.display(),
+        python.display()
+    );
 }
 
 fn validate_bind_host(host: &str, allow_remote: bool) -> Result<()> {

--- a/tests/vdr_auto_start_edges_cli.rs
+++ b/tests/vdr_auto_start_edges_cli.rs
@@ -92,3 +92,40 @@ fn vdr_auto_start_missing_python_path_fails_cleanly() {
         "expected missing interpreter in error, got: {stderr}"
     );
 }
+
+#[test]
+fn vdr_vsplade_missing_runtime_fails_with_actionable_diagnostic() {
+    let (temp, config) = one_image_library();
+    let fake_python = temp.path().join("python-without-splade");
+    std::os::unix::fs::symlink("/usr/bin/false", &fake_python).expect("fake python");
+
+    let output = run_without_embedding_url(
+        &config,
+        &[
+            "vdr",
+            "sync",
+            "--backend",
+            "vsplade",
+            "--python",
+            fake_python.to_str().expect("utf8"),
+            "--max-retries",
+            "0",
+        ],
+        None,
+    );
+
+    assert!(!output.status.success(), "sync should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("V-SPLADE runtime is unavailable")
+            && stderr.contains("splade_mlx")
+            && stderr.contains("--python")
+            && stderr.contains("CLAWGALLERY_PYTHON")
+            && stderr.contains("pip install"),
+        "expected actionable runtime diagnostic, got: {stderr}"
+    );
+    assert!(
+        !stderr.contains("Traceback"),
+        "raw Python traceback should not leak, got: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #15.

- Check the selected V-SPLADE Python interpreter for `splade_mlx` before starting the managed server.
- Replace the raw child-process traceback with an actionable diagnostic naming the interpreter and remediation flags.
- Document the runtime prerequisite and add CLI regression coverage.

## Verification

- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- Live real-model E2E: `cargo test --test vsplade_live_cli -- --ignored --exact live_vsplade_lexical_and_hybrid_search`
  - passed in 21.72s
  - indexed 2 images
  - validated lexical and hybrid search
  - used `/Users/jeffrey/Projects/SPLADE-mlx/.venv/bin/python`
  - emitted only the known Transformers model-type compatibility warning