### PR TITLE
ci: avoid stale cargo cache cleanup annotations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ jobs:
           components: rustfmt, clippy
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
+        with:
+          # cargo package removes verified target/package directories before
+          # rust-cache post-cleanup, so caching target creates stale paths.
+          cache-targets: false
       - name: Format
         run: cargo fmt --all -- --check
       - name: Clippy

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,10 @@ jobs:
           components: rustfmt, clippy
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
+        with:
+          # cargo package removes verified target/package directories before
+          # rust-cache post-cleanup, so caching target creates stale paths.
+          cache-targets: false
       - name: Verify workspace
         run: |
           cargo fmt --all -- --check


### PR DESCRIPTION
## Summary

- Disable rust-cache target caching in CI and crates.io publish workflows.
- Prevent post-cleanup ENOENT annotations for already-removed cargo package directories.

## Findings

The reported paths tests/trybuild and tests/target are not package contents and are not present in the repository. They are stale paths from rust-cache post-cleanup after cargo package removes target/package artifacts.

## Verification

- cargo fmt --all -- --check
- cargo package -p clawgallery-vdr --allow-dirty --list
- cargo package -p clawgallery --allow-dirty --list
- Confirmed neither package list contains tests/trybuild or tests/target.
- git diff --check