### PR TITLE
feat(search): expose index capabilities and enforce mode contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `vdr status --json` reports dense and sparse index availability separately, including model, dimensions, and active vector counts
+- Hybrid search JSON now includes `used_channels`, `skipped_channels`, and `degraded` so callers can distinguish true hybrid results from keyword-only or single-channel fusion
+- `--mode embedding` and `--mode lexical` fail before query embedding when the matching index is missing, with the exact `vdr sync` command needed to build it
+
 ## [0.2.1] — 2026-08-26
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -92,7 +92,9 @@ You'll need credentials for a provider (see [Vision model setup](#vision-model-s
 
 ### 3. Search
 
-By default, search is **hybrid**: Reciprocal Rank Fusion over keyword matches, V-SPLADE lexical ranks (if you synced `--backend vsplade`), and dense VDR ranks (if you built a visual index).
+By default, search is **hybrid**: Reciprocal Rank Fusion over keyword matches, V-SPLADE lexical ranks (if you synced `--backend vsplade`), and dense VDR ranks (if you built a visual index). Missing vector channels degrade instead of failing: keyword-only, keyword+dense, or keyword+sparse. Hybrid `--json` rows include `used_channels`, `skipped_channels`, and `degraded` so callers can tell a true hybrid result from a degraded one.
+
+`--mode embedding` requires an active dense index; `--mode lexical` requires an active V-SPLADE index. Both fail before starting a query-embedding server and print the `vdr sync` command needed to build the missing index. `--mode keyword` always searches captions/paths and never needs a VDR server.
 
 ```bash
 clawgallery search "login error"
@@ -100,6 +102,7 @@ clawgallery search "login error" --json --limit 5
 clawgallery search --mode keyword "github actions"    # caption/path text only
 clawgallery search --mode lexical "invoice total"     # V-SPLADE sparse retrieval
 clawgallery search --mode embedding "sunset photo"    # dense visual only
+clawgallery vdr status --json                         # dense vs sparse availability
 ```
 
 Search understands fzf-style operators:

--- a/crates/clawgallery-vdr/src/index.rs
+++ b/crates/clawgallery-vdr/src/index.rs
@@ -10,12 +10,24 @@ pub struct ActiveIndexConfig {
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct IndexChannelStatus {
+    pub available: bool,
+    pub model: Option<String>,
+    pub dimensions: Option<usize>,
+    pub active_vectors: usize,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct VdrStatus {
     pub active_images: usize,
     pub active_vectors: usize,
     pub model: Option<String>,
     pub dimensions: Option<usize>,
     pub db: PathBuf,
+    pub keyword: bool,
+    pub dense: IndexChannelStatus,
+    pub sparse: IndexChannelStatus,
+    pub hybrid: bool,
 }
 
 pub(super) fn latest_active_index_config(conn: &Connection) -> Result<Option<ActiveIndexConfig>> {
@@ -61,18 +73,45 @@ fn latest_index_config(
     Ok(config.optional()?)
 }
 
+fn active_vector_count(conn: &Connection, encoding: Option<&str>) -> Result<usize> {
+    match encoding {
+        Some(encoding) => Ok(conn.query_row(
+            "select count(*) from vdr_embeddings where active = 1 and encoding = ?1",
+            [encoding],
+            |row| row.get(0),
+        )?),
+        None => Ok(conn.query_row(
+            "select count(*) from vdr_embeddings where active = 1",
+            [],
+            |row| row.get(0),
+        )?),
+    }
+}
+
+fn channel_status(conn: &Connection, encoding: &str) -> Result<IndexChannelStatus> {
+    let config = latest_index_config(conn, Some(encoding))?;
+    Ok(IndexChannelStatus {
+        available: config.is_some(),
+        model: config.as_ref().map(|value| value.model.clone()),
+        dimensions: config.as_ref().map(|value| value.dimensions),
+        active_vectors: active_vector_count(conn, Some(encoding))?,
+    })
+}
+
 pub(super) fn status(db_path: &Path, active_images: usize, conn: &Connection) -> Result<VdrStatus> {
-    let active_vectors: usize = conn.query_row(
-        "select count(*) from vdr_embeddings where active = 1",
-        [],
-        |row| row.get(0),
-    )?;
+    let active_vectors = active_vector_count(conn, None)?;
     let config = latest_any_index_config(conn)?;
+    let dense = channel_status(conn, "dense")?;
+    let sparse = channel_status(conn, "sparse")?;
     Ok(VdrStatus {
         active_images,
         active_vectors,
         model: config.as_ref().map(|value| value.model.clone()),
         dimensions: config.map(|value| value.dimensions),
         db: db_path.to_path_buf(),
+        keyword: true,
+        dense,
+        sparse,
+        hybrid: true,
     })
 }

--- a/crates/clawgallery-vdr/src/lib.rs
+++ b/crates/clawgallery-vdr/src/lib.rs
@@ -14,7 +14,7 @@ mod sparse;
 mod store;
 
 pub use client::DEFAULT_MAX_RETRIES;
-pub use index::{ActiveIndexConfig, VdrStatus};
+pub use index::{ActiveIndexConfig, IndexChannelStatus, VdrStatus};
 pub use search::{EmbeddingSearchHit, late_interaction_score};
 pub use sparse::{SparseVector, rrf_score};
 

--- a/crates/clawgallery-vdr/tests/reusable_api.rs
+++ b/crates/clawgallery-vdr/tests/reusable_api.rs
@@ -67,6 +67,14 @@ fn reusable_vdr_api_indexes_and_searches_documents() {
     assert_eq!(hits[0].score, 1.0);
     assert_eq!(vdr_status.active_images, 1);
     assert_eq!(vdr_status.active_vectors, 2);
+    assert!(vdr_status.keyword);
+    assert!(vdr_status.hybrid);
+    assert!(vdr_status.dense.available);
+    assert_eq!(vdr_status.dense.model.as_deref(), Some("test-model"));
+    assert_eq!(vdr_status.dense.dimensions, Some(4));
+    assert_eq!(vdr_status.dense.active_vectors, 2);
+    assert!(!vdr_status.sparse.available);
+    assert_eq!(vdr_status.sparse.active_vectors, 0);
 }
 
 struct FakeEmbeddingServer {

--- a/skills/clawgallery/SKILL.md
+++ b/skills/clawgallery/SKILL.md
@@ -71,7 +71,7 @@ clawgallery search "'github" "actions" --json
 clawgallery search "!error" "^login"
 ```
 
-Search atoms follow fzf-like rules for the keyword side: whitespace means AND, `'foo` exact substring, `^foo` prefix, `foo$` suffix, `!foo` exclusion, and `\ ` literal space. When a VDR or V-SPLADE index exists, default search fuses those rankings with keyword search via Reciprocal Rank Fusion. Add `--mode keyword` for caption/path keyword search only, `--mode lexical` for V-SPLADE sparse retrieval, `--mode embedding` for dense VDR only, or `--no-fuzzy` for old exact-substring behavior.
+Search atoms follow fzf-like rules for the keyword side: whitespace means AND, `'foo` exact substring, `^foo` prefix, `foo$` suffix, `!foo` exclusion, and `\ ` literal space. When a VDR or V-SPLADE index exists, default search fuses those rankings with keyword search via Reciprocal Rank Fusion and reports `used_channels`, `skipped_channels`, and `degraded` on `--json` rows. Missing vector channels degrade; they do not fail hybrid search. Add `--mode keyword` for caption/path keyword search only, `--mode lexical` for V-SPLADE sparse retrieval, `--mode embedding` for dense VDR only, or `--no-fuzzy` for old exact-substring behavior. `--mode embedding` and `--mode lexical` fail immediately when the matching index is absent and include the `vdr sync` command to build it. Inspect availability with `clawgallery vdr status --json` (`dense` / `sparse` objects).
 
 ## V-SPLADE lexical search
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1587,6 +1587,14 @@ struct SearchResult {
     matched_atoms: Vec<String>,
     source: HitSource,
     discovered_at: DateTime<Utc>,
+    retrieval: Option<HybridRetrieval>,
+}
+
+#[derive(Debug, Clone)]
+struct HybridRetrieval {
+    used: Vec<&'static str>,
+    skipped: Vec<&'static str>,
+    degraded: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -1977,6 +1985,7 @@ fn search_result_from_keyword_hit(hit: &SearchHit, candidate: &SearchCandidate) 
         matched_atoms: hit.matched_atoms.clone(),
         source: hit.source,
         discovered_at: candidate.discovered_at,
+        retrieval: None,
     }
 }
 
@@ -1996,6 +2005,7 @@ fn search_result_from_embedding_hit(hit: clawgallery_vdr::EmbeddingSearchHit) ->
         matched_atoms: hit.matched_atoms,
         source,
         discovered_at: Utc::now(),
+        retrieval: None,
     }
 }
 
@@ -2012,19 +2022,52 @@ fn print_text_search_result(hit: &SearchResult) {
 }
 
 fn print_json_search_result(hit: &SearchResult) -> Result<()> {
-    println!(
-        "{}",
-        serde_json::to_string(&json!({
-            "path": hit.path_raw,
-            "title": hit.title,
-            "description": hit.description,
-            "score": hit.score,
-            "matched_field": hit.matched_field,
-            "matched_atoms": hit.matched_atoms,
-            "source": hit.source,
-        }))?
-    );
+    let mut value = json!({
+        "path": hit.path_raw,
+        "title": hit.title,
+        "description": hit.description,
+        "score": hit.score,
+        "matched_field": hit.matched_field,
+        "matched_atoms": hit.matched_atoms,
+        "source": hit.source,
+    });
+    if let Some(retrieval) = &hit.retrieval {
+        value["used_channels"] = json!(retrieval.used);
+        value["skipped_channels"] = json!(retrieval.skipped);
+        value["degraded"] = json!(retrieval.degraded);
+    }
+    println!("{}", serde_json::to_string(&value)?);
     Ok(())
+}
+
+fn hybrid_retrieval(dense: bool, sparse: bool) -> HybridRetrieval {
+    let mut used = vec!["keyword"];
+    let mut skipped = Vec::new();
+    if dense {
+        used.push("embedding");
+    } else {
+        skipped.push("embedding");
+    }
+    if sparse {
+        used.push("lexical");
+    } else {
+        skipped.push("lexical");
+    }
+    HybridRetrieval {
+        used,
+        skipped,
+        degraded: !dense || !sparse,
+    }
+}
+
+fn print_hybrid_retrieval_diagnostic(retrieval: &HybridRetrieval) {
+    if retrieval.degraded {
+        eprintln!(
+            "(hybrid degraded: used {}; skipped {})",
+            retrieval.used.join(", "),
+            retrieval.skipped.join(", ")
+        );
+    }
 }
 
 fn keyword_search_hits(
@@ -2223,6 +2266,9 @@ fn cmd_search(paths: &AppPaths, args: SearchArgs) -> Result<()> {
         println!("(no fuzzy matches; falling back to typo-tolerant search)");
     }
     if matches!(args.mode, SearchMode::Hybrid) {
+        let dense_available = vdr::latest_dense_index_config(&paths.vdr_db)?.is_some();
+        let sparse_available = vdr::latest_sparse_index_config(&paths.vdr_db)?.is_some();
+        let retrieval = hybrid_retrieval(dense_available, sparse_available);
         let embedding_hits = vdr::embedding_search_hits(
             paths,
             &query,
@@ -2241,12 +2287,18 @@ fn cmd_search(paths: &AppPaths, args: SearchArgs) -> Result<()> {
             latest_images(paths)?,
             latest_captions_by_path(paths)?,
         )?;
-        let results = merge_hybrid_results(
+        let mut results = merge_hybrid_results(
             &hits.iter().take(keyword_limit).cloned().collect::<Vec<_>>(),
             vec![lexical_hits, embedding_hits],
             &candidates,
             args.limit,
         );
+        for result in &mut results {
+            result.retrieval = Some(retrieval.clone());
+        }
+        if !args.json {
+            print_hybrid_retrieval_diagnostic(&retrieval);
+        }
         for result in results {
             if args.json {
                 print_json_search_result(&result)?;

--- a/src/vdr/mod.rs
+++ b/src/vdr/mod.rs
@@ -4,8 +4,8 @@ use clap::{Args, Subcommand};
 use clawgallery_vdr::{
     CaptionDocument, EmbeddingSearchHit, ImageDocument, SearchConfig, SyncConfig, SyncOutcome,
     VectorEncoding, deactivate_image_vectors as deactivate_library_vectors, embedding_search,
-    latest_dense_index_config, latest_sparse_index_config, lexical_search, pending_embedding_count,
-    similar_image_groups as library_similar_image_groups, status as library_status, sync,
+    lexical_search, pending_embedding_count, similar_image_groups as library_similar_image_groups,
+    status as library_status, sync,
 };
 use std::{collections::HashMap, env, path::PathBuf};
 
@@ -13,9 +13,12 @@ mod backend;
 mod serve;
 
 pub(crate) use backend::ServeBackend;
-use backend::{DEFAULT_MANAGED_HOST, DEFAULT_MLX_DIMENSIONS, DEFAULT_MLX_MODEL, resolve_backend};
+use backend::{DEFAULT_MANAGED_HOST, resolve_backend};
 pub(crate) use clawgallery_vdr::SimilarImageGroup;
-pub(crate) use clawgallery_vdr::{DEFAULT_DIMENSIONS, DEFAULT_MAX_RETRIES, DEFAULT_VDR_MODEL};
+pub(crate) use clawgallery_vdr::{
+    DEFAULT_DIMENSIONS, DEFAULT_MAX_RETRIES, DEFAULT_VDR_MODEL, latest_dense_index_config,
+    latest_sparse_index_config,
+};
 
 #[derive(Debug, Args)]
 pub(crate) struct VdrArgs {
@@ -191,8 +194,28 @@ fn cmd_status(paths: &AppPaths, args: VdrStatusArgs) -> Result<()> {
         if let Some(dimensions) = status.dimensions {
             println!("dimensions: {dimensions}");
         }
+        println!("keyword: {}", status.keyword);
+        println!("{}", format_channel("dense", &status.dense));
+        println!("{}", format_channel("sparse", &status.sparse));
+        println!("hybrid: {}", status.hybrid);
     }
     Ok(())
+}
+
+fn format_channel(name: &str, channel: &clawgallery_vdr::IndexChannelStatus) -> String {
+    if channel.available {
+        format!(
+            "{name}: available model={} dimensions={} active_vectors={}",
+            channel.model.as_deref().unwrap_or("<unknown>"),
+            channel
+                .dimensions
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "<unknown>".to_string()),
+            channel.active_vectors
+        )
+    } else {
+        format!("{name}: missing")
+    }
 }
 
 fn encoding_for(backend: ServeBackend) -> VectorEncoding {
@@ -211,14 +234,14 @@ pub(crate) fn embedding_search_hits(
     images: Vec<ImageRecord>,
     captions: HashMap<PathBuf, CaptionRecord>,
 ) -> Result<Vec<EmbeddingSearchHit>> {
-    let index = latest_dense_index_config(&paths.vdr_db)?;
-    if index.is_none() && skip_empty_index {
-        return Ok(Vec::new());
-    }
-    let (model, dimensions) = match index {
-        Some(index) => (index.model, index.dimensions),
-        None => (DEFAULT_MLX_MODEL.to_string(), DEFAULT_MLX_DIMENSIONS),
+    let Some(index) = latest_dense_index_config(&paths.vdr_db)? else {
+        if skip_empty_index {
+            return Ok(Vec::new());
+        }
+        bail!("no dense VDR index; run `clawgallery vdr sync --backend mlx`");
     };
+    let model = index.model;
+    let dimensions = index.dimensions;
     let backend = resolve_backend(None, Some(&model), Some(dimensions))?;
     let env_embedding_url = env::var("CLAWGALLERY_VDR_EMBEDDING_URL").ok();
     let managed_server = if embedding_url.is_none() && env_embedding_url.is_none() {

--- a/tests/vdr_cli.rs
+++ b/tests/vdr_cli.rs
@@ -745,6 +745,16 @@ fn embedding_search_uses_latest_index_model_and_dimensions() {
 
     // Then: search uses the latest active index config instead of default dimensions.
     assert!(search.contains("dog.png"), "got: {search}");
+    let status: serde_json::Value = serde_json::from_str(&assert_success(run(
+        &config,
+        &["vdr", "status", "--json"],
+        server.url(),
+    )))
+    .expect("status json");
+    assert_eq!(status["dense"]["available"], true);
+    assert_eq!(status["dense"]["model"], "custom-jina");
+    assert_eq!(status["dense"]["dimensions"], 4);
+    assert_eq!(status["sparse"]["available"], false);
 }
 
 #[test]
@@ -774,6 +784,19 @@ fn keyword_search_without_embedding_preserves_fuzzy_ranking() {
             .expect("json result");
     assert_eq!(first["source"], "fuzzy");
     assert!(first["path"].as_str().expect("path").ends_with("login.png"));
+    assert_eq!(first["degraded"], true);
+    assert_eq!(first["used_channels"], serde_json::json!(["keyword"]));
+    let skipped = first["skipped_channels"]
+        .as_array()
+        .expect("skipped channels");
+    assert!(
+        skipped.iter().any(|value| value == "embedding"),
+        "keyword-only hybrid should skip embedding, got: {first}"
+    );
+    assert!(
+        skipped.iter().any(|value| value == "lexical"),
+        "keyword-only hybrid should skip lexical, got: {first}"
+    );
     assert_eq!(
         server.request_count(),
         0,
@@ -946,6 +969,16 @@ fn dense_and_sparse_indexes_coexist_after_separate_syncs() {
         status["active_vectors"], 3,
         "dense image+caption plus sparse image must stay active, got: {status}"
     );
+    assert_eq!(status["keyword"], true);
+    assert_eq!(status["hybrid"], true);
+    assert_eq!(status["dense"]["available"], true);
+    assert_eq!(status["dense"]["model"], "dense-test");
+    assert_eq!(status["dense"]["dimensions"], 4);
+    assert_eq!(status["dense"]["active_vectors"], 2);
+    assert_eq!(status["sparse"]["available"], true);
+    assert_eq!(status["sparse"]["model"], "vsplade-test");
+    assert_eq!(status["sparse"]["dimensions"], 8);
+    assert_eq!(status["sparse"]["active_vectors"], 1);
 
     let embedding = assert_success(run(
         &config,
@@ -1048,5 +1081,286 @@ fn lexical_search_without_index_explains_how_to_build_it() {
     assert!(
         stderr.contains("vdr sync --backend vsplade"),
         "got: {stderr}"
+    );
+}
+
+#[test]
+fn vdr_status_json_reports_missing_indexes_separately() {
+    let server = FakeEmbeddingServer::start();
+    let temp = tempfile::tempdir().expect("tempdir");
+    let config = temp.path().join("state");
+    let images = temp.path().join("images");
+    fs::create_dir_all(&images).expect("create images");
+    fs::write(images.join("dog.png"), b"dog image bytes").expect("write dog image");
+    assert_success(run(&config, &["init"], server.url()));
+    assert_success(run(
+        &config,
+        &["bootstrap", "--path", images.to_str().expect("utf8")],
+        server.url(),
+    ));
+
+    let status: serde_json::Value = serde_json::from_str(&assert_success(run(
+        &config,
+        &["vdr", "status", "--json"],
+        server.url(),
+    )))
+    .expect("status json");
+    assert_eq!(status["keyword"], true);
+    assert_eq!(status["hybrid"], true);
+    assert_eq!(status["dense"]["available"], false);
+    assert_eq!(status["dense"]["active_vectors"], 0);
+    assert_eq!(status["sparse"]["available"], false);
+    assert_eq!(status["sparse"]["active_vectors"], 0);
+    assert_eq!(status["active_vectors"], 0);
+}
+
+#[test]
+fn embedding_search_without_dense_index_fails_before_query_embedding() {
+    let server = FakeEmbeddingServer::start();
+    let temp = tempfile::tempdir().expect("tempdir");
+    let config = temp.path().join("state");
+    let images = temp.path().join("images");
+    fs::create_dir_all(&images).expect("create images");
+    fs::write(images.join("dog.png"), b"dog image bytes").expect("write dog image");
+    assert_success(run(&config, &["init"], server.url()));
+    assert_success(run(
+        &config,
+        &["bootstrap", "--path", images.to_str().expect("utf8")],
+        server.url(),
+    ));
+    let before = server.request_count();
+
+    let output = run(
+        &config,
+        &["search", "--mode", "embedding", "sunset photo", "--json"],
+        server.url(),
+    );
+
+    assert!(
+        !output.status.success(),
+        "missing dense index must fail before query embedding"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("no dense VDR index"), "got: {stderr}");
+    assert!(stderr.contains("vdr sync --backend mlx"), "got: {stderr}");
+    assert_eq!(
+        server.request_count(),
+        before,
+        "embedding mode must not call the query endpoint without a dense index"
+    );
+}
+
+#[test]
+fn sparse_only_library_rejects_embedding_mode_and_accepts_lexical() {
+    let server = FakeEmbeddingServer::start();
+    let temp = tempfile::tempdir().expect("tempdir");
+    let config = temp.path().join("state");
+    let images = temp.path().join("images");
+    fs::create_dir_all(&images).expect("create images");
+    fs::write(images.join("dog.png"), b"dog image bytes").expect("write dog image");
+    assert_success(run(&config, &["init"], server.url()));
+    assert_success(run(
+        &config,
+        &["bootstrap", "--path", images.to_str().expect("utf8")],
+        server.url(),
+    ));
+    let (dog_id, dog_path) = image_id_for(&config, "dog.png");
+    write_caption(&config, &dog_id, &dog_path, "Animal Photo", "puppy playing");
+    assert_success(run(
+        &config,
+        &[
+            "vdr",
+            "sync",
+            "--backend",
+            "vsplade",
+            "--model",
+            "vsplade-test",
+            "--dimensions",
+            "8",
+        ],
+        server.url(),
+    ));
+    let after_sync = server.request_count();
+
+    let output = run(
+        &config,
+        &["search", "--mode", "embedding", "dog", "--json"],
+        server.url(),
+    );
+    assert!(
+        !output.status.success(),
+        "sparse-only library must reject embedding mode"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("no dense VDR index"), "got: {stderr}");
+    assert!(stderr.contains("vdr sync --backend mlx"), "got: {stderr}");
+    assert_eq!(
+        server.request_count(),
+        after_sync,
+        "embedding mode must not query-embed against a sparse-only index"
+    );
+
+    let lexical = assert_success(run(
+        &config,
+        &["search", "--mode", "lexical", "dog", "--json"],
+        server.url(),
+    ));
+    let row: serde_json::Value =
+        serde_json::from_str(lexical.lines().next().expect("lexical hit")).expect("json");
+    assert_eq!(row["source"], "lexical");
+    assert!(row["path"].as_str().expect("path").ends_with("dog.png"));
+}
+
+#[test]
+fn dense_only_library_rejects_lexical_mode_and_accepts_embedding() {
+    let server = FakeEmbeddingServer::start();
+    let temp = tempfile::tempdir().expect("tempdir");
+    let config = temp.path().join("state");
+    let images = temp.path().join("images");
+    fs::create_dir_all(&images).expect("create images");
+    fs::write(images.join("dog.png"), b"dog image bytes").expect("write dog image");
+    assert_success(run(&config, &["init"], server.url()));
+    assert_success(run(
+        &config,
+        &["bootstrap", "--path", images.to_str().expect("utf8")],
+        server.url(),
+    ));
+    let (dog_id, dog_path) = image_id_for(&config, "dog.png");
+    write_caption(&config, &dog_id, &dog_path, "Animal Photo", "puppy playing");
+    assert_success(run(
+        &config,
+        &["vdr", "sync", "--model", "dense-test", "--dimensions", "4"],
+        server.url(),
+    ));
+    let after_sync = server.request_count();
+
+    let output = run(
+        &config,
+        &["search", "--mode", "lexical", "dog", "--json"],
+        server.url(),
+    );
+    assert!(
+        !output.status.success(),
+        "dense-only library must reject lexical mode"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("vdr sync --backend vsplade"),
+        "got: {stderr}"
+    );
+    assert_eq!(
+        server.request_count(),
+        after_sync,
+        "lexical mode must not query-embed against a dense-only index"
+    );
+
+    let embedding = assert_success(run(
+        &config,
+        &["search", "--mode", "embedding", "dog", "--json"],
+        server.url(),
+    ));
+    let row: serde_json::Value =
+        serde_json::from_str(embedding.lines().next().expect("embedding hit")).expect("json");
+    assert_eq!(row["source"], "embedding");
+    assert!(row["path"].as_str().expect("path").ends_with("dog.png"));
+}
+
+#[test]
+fn hybrid_search_with_dense_and_sparse_reports_both_channels() {
+    let server = FakeEmbeddingServer::start();
+    let temp = tempfile::tempdir().expect("tempdir");
+    let config = temp.path().join("state");
+    let images = temp.path().join("images");
+    fs::create_dir_all(&images).expect("create images");
+    fs::write(images.join("dog.png"), b"dog image bytes").expect("write dog image");
+    assert_success(run(&config, &["init"], server.url()));
+    assert_success(run(
+        &config,
+        &["bootstrap", "--path", images.to_str().expect("utf8")],
+        server.url(),
+    ));
+    let (dog_id, dog_path) = image_id_for(&config, "dog.png");
+    write_caption(&config, &dog_id, &dog_path, "Animal Photo", "puppy playing");
+    assert_success(run(
+        &config,
+        &["vdr", "sync", "--model", "dense-test", "--dimensions", "4"],
+        server.url(),
+    ));
+    assert_success(run(
+        &config,
+        &[
+            "vdr",
+            "sync",
+            "--backend",
+            "vsplade",
+            "--model",
+            "vsplade-test",
+            "--dimensions",
+            "8",
+        ],
+        server.url(),
+    ));
+
+    let stdout = assert_success(run(
+        &config,
+        &["search", "dog", "--json", "--limit", "5"],
+        server.url(),
+    ));
+    let rows: Vec<serde_json::Value> = stdout
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("json result"))
+        .collect();
+    assert!(
+        !rows.is_empty(),
+        "hybrid search should return hits, got: {stdout}"
+    );
+    for row in &rows {
+        assert_eq!(row["degraded"], false, "got: {row}");
+        let used = row["used_channels"].as_array().expect("used channels");
+        assert!(used.iter().any(|value| value == "keyword"), "got: {row}");
+        assert!(used.iter().any(|value| value == "embedding"), "got: {row}");
+        assert!(used.iter().any(|value| value == "lexical"), "got: {row}");
+        assert_eq!(row["skipped_channels"], serde_json::json!([]));
+    }
+    assert!(
+        rows.iter().any(|row| {
+            let path = row["path"].as_str().expect("path");
+            let fields = row["matched_field"].as_str().unwrap_or_default();
+            path.ends_with("dog.png") && fields.contains("lexical") && fields.contains("embedding")
+        }),
+        "hybrid output should include lexical and embedding contributions, got: {stdout}"
+    );
+}
+
+#[test]
+fn keyword_mode_works_without_vector_indexes() {
+    let server = FakeEmbeddingServer::start();
+    let temp = tempfile::tempdir().expect("tempdir");
+    let config = temp.path().join("state");
+    let images = temp.path().join("images");
+    fs::create_dir_all(&images).expect("create images");
+    fs::write(images.join("login.png"), b"login").expect("write image");
+    assert_success(run(&config, &["init"], server.url()));
+    assert_success(run(
+        &config,
+        &["bootstrap", "--path", images.to_str().expect("utf8")],
+        server.url(),
+    ));
+    let (id, path) = image_id_for(&config, "login.png");
+    write_caption(&config, &id, &path, "Login Dialog", "A settings screen");
+
+    let stdout = assert_success(run(
+        &config,
+        &["search", "--mode", "keyword", "login", "--json"],
+        server.url(),
+    ));
+    let first: serde_json::Value =
+        serde_json::from_str(stdout.lines().next().expect("keyword result")).expect("json");
+    assert_eq!(first["source"], "fuzzy");
+    assert!(first["path"].as_str().expect("path").ends_with("login.png"));
+    assert_eq!(
+        server.request_count(),
+        0,
+        "keyword mode must not call the embedding server"
     );
 }


### PR DESCRIPTION
## Summary

Makes dense vs sparse index capabilities part of the public contract so callers stop inferring them from later embedding failures.

- `vdr status --json` now reports `keyword`, `dense`, `sparse`, and `hybrid`, with per-channel `available` / `model` / `dimensions` / `active_vectors`
- `--mode embedding` fails before query embedding when no dense index exists (`clawgallery vdr sync --backend mlx`)
- `--mode lexical` already failed for a missing sparse index; dense-only libraries now fail the same way before a sparse query
- Default hybrid search still degrades to keyword-only / keyword+dense / keyword+sparse, and `--json` rows include `used_channels`, `skipped_channels`, and `degraded`

Fixes #18

## Checklist

- [x] `make ci` passes locally
- [x] Tests cover the new or fixed behavior
- [x] README / skill usage updated if the CLI surface changed
- [x] No secrets or personal paths in the diff
- [x] Security-sensitive paths (rename, forget, embedding bind, error logging) still redact keys and refuse unsafe overwrites

## Test plan

```bash
make ci
cargo test --test vdr_cli -- embedding_search_without_dense_index_fails_before_query_embedding sparse_only_library_rejects_embedding_mode_and_accepts_lexical dense_only_library_rejects_lexical_mode_and_accepts_embedding hybrid_search_with_dense_and_sparse_reports_both_channels vdr_status_json_reports_missing_indexes_separately
```

Manual QA on `target/debug/clawgallery` with a temp library:

- no vector index: status shows dense/sparse missing; hybrid JSON is `degraded` keyword-only; `--mode embedding` / `--mode lexical` fail with the exact sync commands; `--mode keyword` still works
- dense-only: embedding search works, lexical is rejected before query embedding
- dense+sparse: hybrid JSON has `degraded=false`, `used_channels=["keyword","embedding","lexical"]`, and dog.png `matched_field` includes both `lexical_image` and `embedding_image`
