### PR TITLE
feat(vdr): add native Windows V-SPLADE backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,15 @@ jobs:
         run: cargo build --all-features
       - name: Package library crate
         run: cargo package -p clawgallery-vdr
+  windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - name: Verify Windows build and tests
+        run: |
+          cargo fmt --all -- --check
+          cargo test --workspace --all-features
+          cargo build --workspace --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           components: rustfmt, clippy
       - name: Verify Windows build and tests
+        shell: bash
         run: |
           cargo fmt --all -- --check
           cargo test --workspace --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,5 @@ jobs:
           cargo fmt --all -- --check
           cargo test --workspace --all-features
           cargo build --workspace --all-features
+          python -m py_compile scripts/vsplade_torch_server.py scripts/vsplade_server.py
+          python -m unittest tests.vsplade_torch_resolve

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,4 +41,4 @@ jobs:
           cargo test --workspace --all-features
           cargo build --workspace --all-features
           python -m py_compile scripts/vsplade_torch_server.py scripts/vsplade_server.py
-          python -m unittest tests.vsplade_torch_resolve
+          python tests/vsplade_torch_resolve.py

--- a/README.md
+++ b/README.md
@@ -179,14 +179,23 @@ python3 -m pip install git+https://github.com/NomaDamas/SPLADE-mlx.git
 CLAWGALLERY_PYTHON=python3 clawgallery vdr sync --backend vsplade
 ```
 
-On Windows, install the same package into the active environment and use:
+On macOS/Linux, install the MLX package into the active environment. Windows uses
+the native PyTorch V-SPLADE runtime instead, so it does not require Apple MLX:
 
 ```powershell
-python -m pip install git+https://github.com/NomaDamas/SPLADE-mlx.git
+git clone https://github.com/naver/v-splade.git $env:USERPROFILE\v-splade
+python -m pip install torch torchvision transformers pillow safetensors accelerate
+$env:CLAWGALLERY_VSPLADE_REPO = "$env:USERPROFILE\v-splade"
 clawgallery vdr sync --backend vsplade
 ```
 
-Default model: `NomaDamas/v-splade-efficient-mlx` (Apache-2.0, 50368-dim vocabulary). Sparse postings are stored in `vdr.sqlite3` next to dense VDR rows and do not deactivate them.
+The Windows backend selects CUDA automatically when an NVIDIA CUDA runtime is
+available and otherwise uses CPU. It loads `naver/v-splade-efficient` through
+the upstream inference helper. Set `CLAWGALLERY_VSPLADE_REPO` in every shell
+used for sync or search. Default model: `NomaDamas/v-splade-efficient-mlx` on
+MLX and `naver/v-splade-efficient` on Windows (both use a 50368-dim vocabulary).
+Sparse postings are stored in `vdr.sqlite3` next to dense VDR rows and do not
+deactivate them.
 
 ## Visual search (VDR)
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ the native PyTorch V-SPLADE runtime instead, so it does not require Apple MLX:
 
 ```powershell
 git clone https://github.com/naver/v-splade.git $env:USERPROFILE\v-splade
-python -m pip install torch torchvision transformers pillow safetensors accelerate huggingface_hub
+python -m pip install torch torchvision transformers pillow safetensors accelerate huggingface_hub "colpali-engine>=0.3.18"
 $env:CLAWGALLERY_VSPLADE_REPO = "$env:USERPROFILE\v-splade"
 clawgallery vdr sync --backend vsplade
 ```

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ the native PyTorch V-SPLADE runtime instead, so it does not require Apple MLX:
 
 ```powershell
 git clone https://github.com/naver/v-splade.git $env:USERPROFILE\v-splade
-python -m pip install torch torchvision transformers pillow safetensors accelerate huggingface_hub "colpali-engine>=0.3.18"
+python -m pip install torch torchvision "transformers==4.57.6" pillow safetensors accelerate huggingface_hub "colpali-engine>=0.3.18"
 $env:CLAWGALLERY_VSPLADE_REPO = "$env:USERPROFILE\v-splade"
 clawgallery vdr sync --backend vsplade
 ```

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ the native PyTorch V-SPLADE runtime instead, so it does not require Apple MLX:
 
 ```powershell
 git clone https://github.com/naver/v-splade.git $env:USERPROFILE\v-splade
-python -m pip install torch torchvision "transformers==4.57.6" pillow safetensors accelerate huggingface_hub "colpali-engine>=0.3.18"
+python -m pip install torch torchvision "transformers==4.57.6" pillow safetensors accelerate huggingface_hub "colpali-engine==0.3.13"
 $env:CLAWGALLERY_VSPLADE_REPO = "$env:USERPROFILE\v-splade"
 clawgallery vdr sync --backend vsplade
 ```

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ the native PyTorch V-SPLADE runtime instead, so it does not require Apple MLX:
 
 ```powershell
 git clone https://github.com/naver/v-splade.git $env:USERPROFILE\v-splade
-python -m pip install torch torchvision transformers pillow safetensors accelerate
+python -m pip install torch torchvision transformers pillow safetensors accelerate huggingface_hub
 $env:CLAWGALLERY_VSPLADE_REPO = "$env:USERPROFILE\v-splade"
 clawgallery vdr sync --backend vsplade
 ```

--- a/scripts/vsplade_torch_server.py
+++ b/scripts/vsplade_torch_server.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Native Windows/CPU/CUDA V-SPLADE server for ClawGallery.
+
+Set CLAWGALLERY_VSPLADE_REPO to a checkout of NAVER's V-SPLADE repository.
+The server deliberately keeps the same POST /embed contract as the MLX server.
+"""
+from __future__ import annotations
+
+import argparse
+import ipaddress
+import json
+import os
+import re
+import sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+VALID_KINDS = {"image", "text", "caption"}
+DEFAULT_MODEL = "naver/v-splade-efficient"
+DEFAULT_DIMENSIONS = 50368
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8765)
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument("--dimensions", type=int, default=DEFAULT_DIMENSIONS)
+    parser.add_argument("--device", default="auto", choices=["auto", "cuda", "cpu"])
+    parser.add_argument("--allow-remote", action="store_true")
+    return parser.parse_args()
+
+
+def validate_bind_host(args: argparse.Namespace) -> None:
+    if args.allow_remote or args.host == "localhost":
+        return
+    try:
+        if ipaddress.ip_address(args.host).is_loopback:
+            return
+    except ValueError:
+        pass
+    raise SystemExit(
+        f"error: refusing to bind unauthenticated /embed server to {args.host!r} "
+        "without --allow-remote"
+    )
+
+
+def load_encoder(model_name: str, device_name: str):
+    repo = os.environ.get("CLAWGALLERY_VSPLADE_REPO")
+    if not repo:
+        raise SystemExit(
+            "error: CLAWGALLERY_VSPLADE_REPO must point to a V-SPLADE checkout; "
+            "see the Windows setup instructions"
+        )
+    repo_path = Path(repo).resolve()
+    inference_path = repo_path / "examples" / "vsplade_inference.py"
+    if not inference_path.is_file():
+        raise SystemExit(f"error: V-SPLADE inference helper not found at {inference_path}")
+    sys.path.insert(0, str(repo_path))
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("vsplade_inference", inference_path)
+    if spec is None or spec.loader is None:
+        raise SystemExit(f"error: could not load V-SPLADE inference helper at {inference_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    VSPLADEInference = module.VSPLADEInference
+
+    import torch  # type: ignore[import-not-found]
+
+    device = "cuda" if device_name in {"auto", "cuda"} and torch.cuda.is_available() else "cpu"
+    return VSPLADEInference.from_pretrained(model_name, device=device, dtype=torch.float32)
+
+
+def to_sparse(vector, dimensions: int) -> dict[str, list[float] | list[int]]:
+    import torch  # type: ignore[import-not-found]
+
+    dense = vector.detach().float().reshape(-1)
+    if dense.numel() > dimensions:
+        dense = dense[:dimensions]
+    indices = torch.nonzero(dense > 0, as_tuple=False).reshape(-1)
+    return {
+        "indices": indices.cpu().tolist(),
+        "values": dense[indices].cpu().tolist(),
+    }
+
+
+def make_server(model_name: str, dimensions: int, device_name: str) -> type[BaseHTTPRequestHandler]:
+    fake = os.environ.get("CLAWGALLERY_VDR_VSPLADE_FAKE") == "1"
+    encoder = None if fake else load_encoder(model_name, device_name)
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, format: str, *args: object) -> None:
+            return
+
+        def do_POST(self) -> None:
+            if self.path != "/embed":
+                self.send_error(404, "not found")
+                return
+            length = int(self.headers.get("content-length", "0"))
+            payload = json.loads(self.rfile.read(length))
+
+            def send_json(status: int, body: dict) -> None:
+                encoded = json.dumps(body).encode()
+                self.send_response(status)
+                self.send_header("content-type", "application/json")
+                self.send_header("content-length", str(len(encoded)))
+                self.end_headers()
+                self.wfile.write(encoded)
+
+            if payload.get("model", model_name) != model_name:
+                send_json(400, {"error": f"server loaded {model_name}"})
+                return
+            if payload.get("dimensions", dimensions) != dimensions:
+                send_json(400, {"error": f"server loaded dimensions {dimensions}"})
+                return
+            try:
+                embeddings = []
+                for item in payload.get("inputs", []):
+                    kind = item.get("kind")
+                    if kind not in VALID_KINDS:
+                        send_json(400, {"error": f"invalid input kind {kind!r}"})
+                        return
+                    value = str(item.get("value") or "")
+                    if fake:
+                        haystack = (Path(value).name if kind == "image" else value).lower()
+                        if "dog" in haystack or "puppy" in haystack:
+                            index, weight = 1, 2.0
+                        elif "cat" in haystack or "kitten" in haystack:
+                            index, weight = 2, 2.0
+                        else:
+                            tokens = [token for token in re.split(r"[^a-z0-9]+", haystack) if token]
+                            index, weight = sum(ord(char) for char in (tokens[0] if tokens else "x")) % max(dimensions, 1), 1.0
+                        embeddings.append({"indices": [min(index, max(dimensions, 1) - 1)], "values": [weight]})
+                    elif kind == "image":
+                        from PIL import Image
+
+                        assert encoder is not None
+                        with Image.open(value) as image:
+                            embeddings.append(to_sparse(encoder.encode_image(image), dimensions))
+                    else:
+                        assert encoder is not None
+                        embeddings.append(to_sparse(encoder.encode_query(value), dimensions))
+                send_json(
+                    200,
+                    {
+                        "model": model_name,
+                        "dimensions": dimensions,
+                        "format": "sparse",
+                        "embeddings": embeddings,
+                    },
+                )
+            except Exception as exc:  # noqa: BLE001 - return actionable server errors
+                send_json(500, {"error": str(exc)})
+
+    return Handler
+
+
+def main() -> None:
+    args = parse_args()
+    validate_bind_host(args)
+    server = ThreadingHTTPServer((args.host, args.port), make_server(args.model, args.dimensions, args.device))
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/vsplade_torch_server.py
+++ b/scripts/vsplade_torch_server.py
@@ -45,6 +45,24 @@ def validate_bind_host(args: argparse.Namespace) -> None:
     )
 
 
+def resolve_pretrained_source(model_name: str, downloader=None) -> str:
+    """Return a local directory the upstream helper can wrap in Path().
+
+    VSPLADEInference.from_pretrained does ``hf_dir = Path(hf_dir)``. On Windows
+    that turns a Hub repo id such as ``naver/v-splade-efficient`` into
+    ``naver\\v-splade-efficient``, which huggingface_hub rejects. Snapshot the
+    repo first so the helper always receives a real directory.
+    """
+    candidate = Path(model_name)
+    if candidate.exists():
+        return str(candidate.resolve())
+    if downloader is None:
+        from huggingface_hub import snapshot_download  # type: ignore[import-not-found]
+
+        downloader = snapshot_download
+    return downloader(repo_id=model_name)
+
+
 def load_encoder(model_name: str, device_name: str):
     repo = os.environ.get("CLAWGALLERY_VSPLADE_REPO")
     if not repo:
@@ -69,7 +87,8 @@ def load_encoder(model_name: str, device_name: str):
     import torch  # type: ignore[import-not-found]
 
     device = "cuda" if device_name in {"auto", "cuda"} and torch.cuda.is_available() else "cpu"
-    return VSPLADEInference.from_pretrained(model_name, device=device, dtype=torch.float32)
+    source = resolve_pretrained_source(model_name)
+    return VSPLADEInference.from_pretrained(source, device=device, dtype=torch.float32)
 
 
 def to_sparse(vector, dimensions: int) -> dict[str, list[float] | list[int]]:

--- a/src/main.rs
+++ b/src/main.rs
@@ -3020,6 +3020,7 @@ mod tests {
         assert_eq!(mime_for_path(Path::new("photo.heif")), "image/heif");
     }
 
+    #[cfg(unix)]
     #[test]
     fn caption_image_payload_converts_heic_with_configured_converter() {
         use std::os::unix::fs::PermissionsExt;

--- a/src/vdr/backend.rs
+++ b/src/vdr/backend.rs
@@ -8,6 +8,8 @@ const JINA_MLX_MODEL: &str = "jinaai/jina-embeddings-v5-omni-small-retrieval-mlx
 const JINA_MLX_DIMENSIONS: usize = 1024;
 pub(super) const DEFAULT_VSPLADE_MODEL: &str = clawgallery_vdr::DEFAULT_VSPLADE_MODEL;
 pub(super) const DEFAULT_VSPLADE_DIMENSIONS: usize = clawgallery_vdr::DEFAULT_VSPLADE_DIMENSIONS;
+#[cfg(windows)]
+const WINDOWS_VSPLADE_MODEL: &str = "naver/v-splade-efficient";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub(crate) enum ServeBackend {
@@ -40,7 +42,16 @@ pub(super) fn resolve_backend(
     let (default_model, default_dimensions) = match backend {
         ServeBackend::Mlx => (DEFAULT_MLX_MODEL, DEFAULT_MLX_DIMENSIONS),
         ServeBackend::JinaMlx => (JINA_MLX_MODEL, JINA_MLX_DIMENSIONS),
-        ServeBackend::Vsplade => (DEFAULT_VSPLADE_MODEL, DEFAULT_VSPLADE_DIMENSIONS),
+        ServeBackend::Vsplade => {
+            #[cfg(windows)]
+            {
+                (WINDOWS_VSPLADE_MODEL, DEFAULT_VSPLADE_DIMENSIONS)
+            }
+            #[cfg(not(windows))]
+            {
+                (DEFAULT_VSPLADE_MODEL, DEFAULT_VSPLADE_DIMENSIONS)
+            }
+        }
     };
     let model = model.unwrap_or(default_model);
     let dimensions = dimensions.unwrap_or(default_dimensions);

--- a/src/vdr/serve.rs
+++ b/src/vdr/serve.rs
@@ -13,6 +13,7 @@ use std::{
 const MLX_SERVER: &str = include_str!("../../scripts/mlx_embeddings_server.py");
 const JINA_MLX_SERVER: &str = include_str!("../../scripts/jina_mlx_embeddings_server.py");
 const VSPLADE_SERVER: &str = include_str!("../../scripts/vsplade_server.py");
+const VSPLADE_TORCH_SERVER: &str = include_str!("../../scripts/vsplade_torch_server.py");
 const MANAGED_STARTUP_TIMEOUT: Duration = Duration::from_secs(20 * 60);
 
 impl ServeBackend {
@@ -28,7 +29,13 @@ impl ServeBackend {
         match self {
             Self::Mlx => MLX_SERVER,
             Self::JinaMlx => JINA_MLX_SERVER,
-            Self::Vsplade => VSPLADE_SERVER,
+            Self::Vsplade => {
+                if cfg!(windows) {
+                    VSPLADE_TORCH_SERVER
+                } else {
+                    VSPLADE_SERVER
+                }
+            }
         }
     }
 }
@@ -236,8 +243,22 @@ fn check_python_runtime(backend: ServeBackend, python: &PathBuf) -> Result<()> {
     {
         return Ok(());
     }
+    if cfg!(windows) && env::var_os("CLAWGALLERY_VSPLADE_REPO").is_none() {
+        bail!(
+            "V-SPLADE Windows runtime is not configured: set \
+CLAWGALLERY_VSPLADE_REPO to a checkout of https://github.com/naver/v-splade \
+before retrying with --python {} or CLAWGALLERY_PYTHON={}",
+            python.display(),
+            python.display()
+        );
+    }
+    let import = if cfg!(windows) {
+        "import torch, transformers, PIL"
+    } else {
+        "import splade_mlx"
+    };
     let output = Command::new(python)
-        .args(["-c", "import splade_mlx"])
+        .args(["-c", import])
         .output()
         .with_context(|| {
             format!(
@@ -249,10 +270,11 @@ fn check_python_runtime(backend: ServeBackend, python: &PathBuf) -> Result<()> {
         return Ok(());
     }
     bail!(
-        "V-SPLADE runtime is unavailable in {}: could not import splade_mlx. \
-Install SPLADE-mlx in this environment, then retry with \
+        "V-SPLADE runtime is unavailable in {}: the selected interpreter cannot \
+load the supported backend dependencies. Install the Windows PyTorch runtime \
+or SPLADE-mlx as appropriate, then retry with \
 --python {} or CLAWGALLERY_PYTHON={}. \
-Example: {} -m pip install git+https://github.com/NomaDamas/SPLADE-mlx.git",
+Example: {} -m pip install torch transformers pillow",
         python.display(),
         python.display(),
         python.display(),

--- a/tests/jina_mlx_server_http.rs
+++ b/tests/jina_mlx_server_http.rs
@@ -1,3 +1,5 @@
+#![cfg(not(windows))]
+
 use std::{
     io::{BufRead, BufReader, Read, Write},
     net::{Shutdown, TcpListener, TcpStream},

--- a/tests/vdr_auto_start_cli.rs
+++ b/tests/vdr_auto_start_cli.rs
@@ -6,7 +6,13 @@ use vdr_autosync_support::{
 };
 
 fn python_for_mlx_tests() -> String {
-    std::env::var("PYTHON").unwrap_or_else(|_| "python3".to_string())
+    std::env::var("PYTHON").unwrap_or_else(|_| {
+        if cfg!(windows) {
+            "python".to_string()
+        } else {
+            "python3".to_string()
+        }
+    })
 }
 
 #[test]

--- a/tests/vdr_auto_start_edges_cli.rs
+++ b/tests/vdr_auto_start_edges_cli.rs
@@ -94,6 +94,7 @@ fn vdr_auto_start_missing_python_path_fails_cleanly() {
 }
 
 #[test]
+#[cfg(unix)]
 fn vdr_vsplade_missing_runtime_fails_with_actionable_diagnostic() {
     let (temp, config) = one_image_library();
     let fake_python = temp.path().join("python-without-splade");
@@ -118,7 +119,6 @@ fn vdr_vsplade_missing_runtime_fails_with_actionable_diagnostic() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains("V-SPLADE runtime is unavailable")
-            && stderr.contains("splade_mlx")
             && stderr.contains("--python")
             && stderr.contains("CLAWGALLERY_PYTHON")
             && stderr.contains("pip install"),

--- a/tests/vsplade_torch_resolve.py
+++ b/tests/vsplade_torch_resolve.py
@@ -1,0 +1,51 @@
+"""Unit tests for Windows V-SPLADE repo-id resolution.
+
+Upstream VSPLADEInference.from_pretrained wraps its argument in Path().
+On Windows that turns Hub ids like ``naver/v-splade-efficient`` into
+``naver\\v-splade-efficient``, which huggingface_hub rejects. The server must
+snapshot_download the repo first and pass a real local directory.
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import vsplade_torch_server as server  # noqa: E402
+
+
+class ResolvePretrainedSourceTests(unittest.TestCase):
+    def test_repo_id_uses_downloader_not_path(self) -> None:
+        calls: list[dict[str, str]] = []
+
+        def fake_download(*, repo_id: str) -> str:
+            calls.append({"repo_id": repo_id})
+            self.assertNotIn("\\", repo_id)
+            return "/abs/models--naver--v-splade-efficient"
+
+        got = server.resolve_pretrained_source(
+            "naver/v-splade-efficient", downloader=fake_download
+        )
+        self.assertEqual(got, "/abs/models--naver--v-splade-efficient")
+        self.assertEqual(calls, [{"repo_id": "naver/v-splade-efficient"}])
+
+    def test_existing_local_dir_skips_download(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            calls: list[dict[str, str]] = []
+
+            def fake_download(*, repo_id: str) -> str:
+                calls.append({"repo_id": repo_id})
+                return "should-not-run"
+
+            got = server.resolve_pretrained_source(tmp, downloader=fake_download)
+            self.assertEqual(Path(got).resolve(), Path(tmp).resolve())
+            self.assertEqual(calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes #24.

- Add a packaged native PyTorch V-SPLADE server for Windows CPU/CUDA.
- Select the Windows runtime and `naver/v-splade-efficient` defaults automatically.
- Require and diagnose `CLAWGALLERY_VSPLADE_REPO` for the upstream inference helper.
- Document clean Windows setup and add a Windows CI build/test job.
- Preserve the existing MLX path on macOS/Linux.

## Test plan

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `python3 -m py_compile scripts/vsplade_torch_server.py scripts/vsplade_server.py`
- Native server `/embed` contract exercised in fake mode.
- SSH Windows host inspected: Windows 11, Python 3.11.3, Cargo 1.98.0. Native dependency packages were not installed there, so live model inference was not run on that host.
- Cross-target Rust check was attempted but the local GNU Windows target was not installed.
