### PR TITLE
feat(vdr): add Windows ColQwen dense backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Managed `--backend colqwen` dense VDR path for Windows CPU/CUDA via ColQwen2 and colpali-engine
+- Windows setup docs, incomplete Hugging Face cache diagnostics, and a Windows CI job
+
+### Fixed
+
+- `mlx` / `jina-mlx` on Windows now fail immediately with a pointer to `--backend colqwen` instead of importing `mlx_embeddings`
+
 ## [0.2.2] — 2026-08-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -231,6 +231,25 @@ clawgallery vdr status --json
 
 The default model is `qnguyen3/colqwen2.5-v0.2-mlx` (128 dimensions). The first run downloads and caches model weights. If Hugging Face downloads stall on macOS, retry with `HF_HUB_DISABLE_XET=1`.
 
+### Setup (Windows)
+
+MLX backends (`mlx`, `jina-mlx`) are Apple Silicon-only. On Windows, use the managed ColQwen2 PyTorch backend (`vidore/colqwen2-v1.0`, 128 dimensions):
+
+```powershell
+rustup default stable
+python -m venv "$env:LOCALAPPDATA\clawgallery\colqwen"
+& "$env:LOCALAPPDATA\clawgallery\colqwen\Scripts\python.exe" -m pip install -U pip huggingface_hub
+& "$env:LOCALAPPDATA\clawgallery\colqwen\Scripts\python.exe" -m pip install torch --index-url https://download.pytorch.org/whl/cpu
+& "$env:LOCALAPPDATA\clawgallery\colqwen\Scripts\python.exe" -m pip install colpali-engine transformers pillow
+cargo install --path .
+
+$env:CLAWGALLERY_PYTHON = "$env:LOCALAPPDATA\clawgallery\colqwen\Scripts\python.exe"
+clawgallery vdr sync --backend colqwen
+clawgallery search --mode embedding "login error" --json
+```
+
+CUDA hosts can omit the CPU PyTorch index URL and use `--device cuda`. If a previous download stalled at `Fetching 2 files: 0%`, delete `%USERPROFILE%\.cache\huggingface\hub\models--vidore--colqwen2-*`, upgrade `huggingface_hub`, and retry. Some networks need `HF_HUB_DISABLE_XET=1`; others fail DNS for `cdn-lfs.huggingface.co` and need xet left enabled. `mlx` / `jina-mlx` fail immediately with a pointer to `--backend colqwen`.
+
 ### Jina v5 Omni retrieval on Apple Silicon
 
 ClawGallery also packages the MLX conversion of `jinaai/jina-embeddings-v5-omni-small-retrieval-mlx` (1024 dimensions). It requires Apple Silicon and loads the immutable Hugging Face revision `049ae923674456656be891ebb22849dd58124994`.
@@ -268,7 +287,7 @@ You can also set `CLAWGALLERY_VDR_EMBEDDING_URL` instead of passing `--embedding
 <details>
 <summary>External embedding backends (legacy ColQwen2 and SentenceTransformer Jina Omni)</summary>
 
-**Legacy ColQwen2** (`vidore/colqwen2-v1.0`, 128 dims):
+**Legacy ColQwen2** (`vidore/colqwen2-v1.0`, 128 dims). Prefer managed `--backend colqwen` above; this path is for an already-running external server:
 
 ```bash
 uv pip install colpali-engine torch pillow
@@ -396,8 +415,8 @@ clawgallery rename --undo [--last] [--file <path>] [--dry-run]
 clawgallery forget --file <path> [--delete]
 clawgallery dedup [--exact] [--similar] [--threshold <0..1>] [--json]
 clawgallery search [--mode keyword|embedding|lexical|hybrid] <query...> [--limit <n>] [--json] [--case-sensitive] [--no-fuzzy] [--embedding-url <url>]
-clawgallery vdr sync [--prune] [--embedding-url <url>] [--model <model>] [--dimensions <n>] [--max-retries <n>] [--auto-start|--no-auto-start] [--backend mlx|jina-mlx|vsplade] [--host <host>] [--port <port>] [--device auto|mps|cpu] [--python <path>] [--allow-remote]
-clawgallery vdr serve [--backend mlx|jina-mlx|vsplade] [--host <host>] [--port <port>] [--model <model>] [--dimensions <n>] [--device auto|mps|cpu] [--python <path>] [--allow-remote]
+clawgallery vdr sync [--prune] [--embedding-url <url>] [--model <model>] [--dimensions <n>] [--max-retries <n>] [--auto-start|--no-auto-start] [--backend mlx|jina-mlx|colqwen|vsplade] [--host <host>] [--port <port>] [--device auto|mps|cpu|cuda] [--python <path>] [--allow-remote]
+clawgallery vdr serve [--backend mlx|jina-mlx|colqwen|vsplade] [--host <host>] [--port <port>] [--model <model>] [--dimensions <n>] [--device auto|mps|cpu|cuda] [--python <path>] [--allow-remote]
 clawgallery vdr status [--json]
 clawgallery daemon install [--interval <seconds>] [--caption] [--sync] [--path <path>] [--folder <id>]
 clawgallery daemon start|stop|status|uninstall|logs
@@ -406,7 +425,8 @@ clawgallery skill path|print
 ```
 
 `jina-mlx` supports `--device auto|mps`; `cpu` is available only with the
-default `mlx` backend.
+default `mlx` backend. `colqwen` supports `--device auto|cpu|cuda` and is the
+Windows dense default.
 
 ---
 

--- a/scripts/colqwen2_server.py
+++ b/scripts/colqwen2_server.py
@@ -1,31 +1,35 @@
 #!/usr/bin/env python3
-"""Late-interaction (multi-vector) embedding server for ClawGallery VDR.
+"""Managed ColQwen2 dense embedding server for ClawGallery VDR.
 
-Serves vidore/colqwen2-v1.0 via colpali-engine. Speaks the same /embed
-contract as jina_omni_server.py, but returns one multi-vector per input:
-``embeddings`` is a list of ``[[f32, ...], ...]`` (one 128-dim vector per
-image patch / query token) instead of a single pooled vector.
+Serves vidore/colqwen2-v1.0 via colpali-engine on CPU/CUDA. Speaks the same
+POST /embed contract as the MLX server: ``embeddings`` is a list of
+multi-vectors (one 128-d row per image patch / query token).
 
-Requires: pip install colpali-engine torch pillow
+Requires: pip install colpali-engine torch transformers pillow
 """
+from __future__ import annotations
+
 import argparse
 import importlib
 import ipaddress
 import json
+import os
+import re
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
 VALID_KINDS = {"image", "text", "caption"}
-
-
 DEFAULT_MODEL = "vidore/colqwen2-v1.0"
+DEFAULT_DIMENSIONS = 128
+WEIGHT_SUFFIXES = {".safetensors", ".bin", ".pt", ".gguf"}
 
 
-def parse_args():
+def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=8765)
     parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument("--dimensions", type=int, default=DEFAULT_DIMENSIONS)
     parser.add_argument("--device", default="auto", choices=["auto", "mps", "cpu", "cuda"])
     parser.add_argument(
         "--allow-remote",
@@ -35,18 +39,18 @@ def parse_args():
     return parser.parse_args()
 
 
-def choose_device(requested):
+def choose_device(requested: str) -> str:
     if requested != "auto":
         return requested
     torch = importlib.import_module("torch")
-    if torch.backends.mps.is_available():
-        return "mps"
     if torch.cuda.is_available():
         return "cuda"
+    if getattr(torch.backends, "mps", None) is not None and torch.backends.mps.is_available():
+        return "mps"
     return "cpu"
 
 
-def is_loopback_host(host):
+def is_loopback_host(host: str) -> bool:
     if host == "localhost":
         return True
     try:
@@ -55,7 +59,7 @@ def is_loopback_host(host):
         return False
 
 
-def validate_bind_host(args):
+def validate_bind_host(args: argparse.Namespace) -> None:
     if is_loopback_host(args.host) or args.allow_remote:
         return
     raise SystemExit(
@@ -65,58 +69,152 @@ def validate_bind_host(args):
     )
 
 
+def hf_hub_dir() -> Path:
+    if cache := os.environ.get("HUGGINGFACE_HUB_CACHE"):
+        return Path(cache)
+    home = Path(os.environ.get("HF_HOME", Path.home() / ".cache" / "huggingface"))
+    return home / "hub"
 
-def make_server(model_name, device):
-    torch = importlib.import_module("torch")
-    image_module = importlib.import_module("PIL.Image")
-    colpali = importlib.import_module("colpali_engine.models")
-    model = colpali.ColQwen2.from_pretrained(
-        model_name,
-        torch_dtype=torch.bfloat16 if device != "cpu" else torch.float32,
-        device_map=device,
-    ).eval()
-    processor = colpali.ColQwen2Processor.from_pretrained(model_name)
 
-    def embed_images(images):
-        batch = processor.process_images(images).to(model.device)
-        with torch.no_grad():
-            return model(**batch)
+def incomplete_hf_cache_message(model_name: str) -> str | None:
+    root = hf_hub_dir() / f"models--{model_name.replace('/', '--')}"
+    if not root.exists():
+        return None
+    snapshots = root / "snapshots"
+    if not snapshots.is_dir():
+        return (
+            f"Hugging Face cache for {model_name} at {root} has no snapshots. "
+            f"Delete {root} and retry. If downloads stall, toggle HF_HUB_DISABLE_XET "
+            "(cdn-lfs vs xet) after upgrading huggingface_hub."
+        )
+    for snapshot in snapshots.iterdir():
+        if not snapshot.is_dir():
+            continue
+        files = [path for path in snapshot.rglob("*") if path.is_file()]
+        if any(path.suffix in WEIGHT_SUFFIXES for path in files):
+            return None
+        names = ", ".join(path.name for path in files[:8]) or "<empty>"
+        return (
+            f"Hugging Face snapshot for {model_name} is incomplete "
+            f"(no model weights under {snapshot}; found {names}). "
+            f"Delete {root} and retry. If downloads stall, toggle HF_HUB_DISABLE_XET "
+            "(cdn-lfs vs xet) after upgrading huggingface_hub."
+        )
+    return None
 
-    def embed_texts(texts):
-        batch = processor.process_queries(texts).to(model.device)
-        with torch.no_grad():
-            return model(**batch)
 
-    def to_multivectors(tensor):
-        # tensor: (batch, tokens, dim); drop zero-padded rows.
-        multivectors = []
-        for doc in tensor.to(torch.float32).cpu():
-            rows = [row.tolist() for row in doc if float(row.abs().sum()) > 0.0]
-            multivectors.append(rows or [[0.0] * doc.shape[-1]])
-        return multivectors
+def fake_multivector(value: str, dimensions: int) -> list[list[float]]:
+    rows: list[list[float]] = []
+    for word in re.split(r"[^a-z0-9]+", value.lower()):
+        if not word:
+            continue
+        row = [0.0] * dimensions
+        row[sum(ord(char) for char in word) % dimensions] = 1.0
+        rows.append(row)
+    return rows or [[0.0] * dimensions]
+
+
+def load_colqwen(model_name: str, device: str):
+    if message := incomplete_hf_cache_message(model_name):
+        raise SystemExit(f"error: {message}")
+    try:
+        torch = importlib.import_module("torch")
+        colpali = importlib.import_module("colpali_engine.models")
+        model = colpali.ColQwen2.from_pretrained(
+            model_name,
+            torch_dtype=torch.bfloat16 if device != "cpu" else torch.float32,
+            device_map=device,
+        ).eval()
+        processor = colpali.ColQwen2Processor.from_pretrained(model_name)
+        return torch, importlib.import_module("PIL.Image"), model, processor
+    except SystemExit:
+        raise
+    except Exception as exc:  # noqa: BLE001 - surface Hub/runtime failures to the CLI
+        extra = incomplete_hf_cache_message(model_name)
+        hint = extra or (
+            "If Hugging Face downloads stall, delete the incomplete cache, upgrade huggingface_hub, "
+            "and toggle HF_HUB_DISABLE_XET (cdn-lfs vs xet)."
+        )
+        raise SystemExit(f"error: failed to load {model_name}: {exc}. {hint}") from exc
+
+
+def make_server(model_name: str, dimensions: int, device: str, fake: bool) -> type[BaseHTTPRequestHandler]:
+    loaded = None if fake else load_colqwen(model_name, device)
 
     class Handler(BaseHTTPRequestHandler):
-        def do_POST(self):
+        def log_message(self, format: str, *args: object) -> None:
+            return
+
+        def send_json(self, status: int, payload: dict) -> None:
+            body = json.dumps(payload).encode()
+            self.send_response(status)
+            self.send_header("content-type", "application/json")
+            self.send_header("content-length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_POST(self) -> None:
             if self.path != "/embed":
                 self.send_error(404, "not found")
                 return
-            length = int(self.headers.get("content-length", "0"))
-            payload = json.loads(self.rfile.read(length))
-            def send_json_error(status, message):
-                body = json.dumps({"error": message}).encode()
-                self.send_response(status)
-                self.send_header("content-type", "application/json")
-                self.send_header("content-length", str(len(body)))
-                self.end_headers()
-                self.wfile.write(body)
-
-            opened = []
+            if self.headers.get("origin") is not None:
+                self.send_json(403, {"error": "browser-originated requests are not allowed"})
+                return
+            content_type = self.headers.get("content-type", "").partition(";")[0].strip().lower()
+            if content_type != "application/json":
+                self.send_json(415, {"error": "content-type must be application/json"})
+                return
             try:
-                images, texts, order = [], [], []
+                length = int(self.headers.get("content-length", "0"))
+                payload = json.loads(self.rfile.read(length))
+            except (ValueError, json.JSONDecodeError, UnicodeDecodeError):
+                self.send_json(400, {"error": "request body must be valid JSON"})
+                return
+            if payload.get("model", model_name) != model_name:
+                self.send_json(400, {"error": f"server loaded {model_name}"})
+                return
+            if payload.get("dimensions", dimensions) != dimensions:
+                self.send_json(400, {"error": f"server loaded dimensions {dimensions}"})
+                return
+            try:
+                self._embed(payload)
+            except Exception as exc:  # noqa: BLE001 - keep /embed JSON-stable
+                self.send_json(500, {"error": str(exc)})
+
+        def _embed(self, payload: dict) -> None:
+            if fake:
+                embeddings = []
                 for item in payload.get("inputs", []):
                     kind = item.get("kind")
                     if kind not in VALID_KINDS:
-                        send_json_error(400, f"invalid input kind {kind!r}; expected image, text, or caption")
+                        self.send_json(400, {"error": f"invalid input kind {kind!r}; expected image, text, or caption"})
+                        return
+                    value = str(item.get("value", ""))
+                    haystack = Path(value).name if kind == "image" else value
+                    embeddings.append(fake_multivector(haystack, dimensions))
+                self.send_json(200, {"model": model_name, "dimensions": dimensions, "embeddings": embeddings})
+                return
+
+            assert loaded is not None
+            torch, image_module, model, processor = loaded
+
+            def to_multivectors(tensor):
+                multivectors = []
+                for doc in tensor.to(torch.float32).cpu():
+                    rows = [row.tolist() for row in doc if float(row.abs().sum()) > 0.0]
+                    if rows and len(rows[0]) != dimensions:
+                        raise RuntimeError(
+                            f"embedding server returned dimensions {len(rows[0])} but {dimensions} was requested"
+                        )
+                    multivectors.append(rows or [[0.0] * dimensions])
+                return multivectors
+
+            images, texts, order, opened = [], [], [], []
+            try:
+                for item in payload.get("inputs", []):
+                    kind = item.get("kind")
+                    if kind not in VALID_KINDS:
+                        self.send_json(400, {"error": f"invalid input kind {kind!r}; expected image, text, or caption"})
                         return
                     if kind == "image":
                         image = image_module.open(Path(item["value"])).convert("RGB")
@@ -126,49 +224,49 @@ def make_server(model_name, device):
                     else:
                         order.append(("text", len(texts)))
                         texts.append(str(item.get("value", "")))
-                image_vectors = to_multivectors(embed_images(images)) if images else []
-                text_vectors = to_multivectors(embed_texts(texts)) if texts else []
+                image_vectors = []
+                if images:
+                    batch = processor.process_images(images).to(model.device)
+                    with torch.no_grad():
+                        image_vectors = to_multivectors(model(**batch))
+                text_vectors = []
+                if texts:
+                    batch = processor.process_queries(texts).to(model.device)
+                    with torch.no_grad():
+                        text_vectors = to_multivectors(model(**batch))
                 embeddings = [
                     image_vectors[index] if kind == "image" else text_vectors[index]
                     for kind, index in order
                 ]
-                dimensions = len(embeddings[0][0]) if embeddings else 0
-                body = json.dumps(
-                    {
-                        "model": model_name,
-                        "dimensions": dimensions,
-                        "embeddings": embeddings,
-                    }
-                ).encode()
-                self.send_response(200)
-                self.send_header("content-type", "application/json")
-                self.send_header("content-length", str(len(body)))
-                self.end_headers()
-                self.wfile.write(body)
-            except Exception as exc:
-                send_json_error(500, str(exc))
+                self.send_json(200, {"model": model_name, "dimensions": dimensions, "embeddings": embeddings})
             finally:
                 for image in opened:
                     image.close()
 
-        def log_message(self, format, *args):
-            return
-
     return Handler
 
 
-def main():
+def main() -> None:
     args = parse_args()
     validate_bind_host(args)
-    device = choose_device(args.device)
-    handler = make_server(args.model, device)
-    server = ThreadingHTTPServer((args.host, args.port), handler)
+    fake = os.environ.get("CLAWGALLERY_VDR_COLQWEN_FAKE") == "1"
+    if not fake:
+        if message := incomplete_hf_cache_message(args.model):
+            raise SystemExit(f"error: {message}")
+    device = "cpu" if fake else choose_device(args.device)
+    server = ThreadingHTTPServer(
+        (args.host, args.port),
+        make_server(args.model, args.dimensions, device, fake),
+    )
     print(
         json.dumps(
             {
                 "url": f"http://{args.host}:{args.port}",
                 "model": args.model,
+                "dimensions": args.dimensions,
+                "backend": "colqwen",
                 "device": device,
+                "fake": fake,
             }
         ),
         flush=True,

--- a/skills/clawgallery/SKILL.md
+++ b/skills/clawgallery/SKILL.md
@@ -130,6 +130,8 @@ clawgallery vdr status --json
 
 `clawgallery vdr sync` starts the packaged MLX `/embed` daemon automatically when no `--embedding-url` and no `CLAWGALLERY_VDR_EMBEDDING_URL` are configured, waits for it, lets the model runtime download/cache weights as needed, indexes active images, and terminates it before exit. Default search and `--mode embedding` also start a managed MLX server automatically for the query embedding when an index exists and no compatible endpoint is configured. Pass `--no-auto-start` to require an external server during sync.
 
+Windows dense VDR uses `--backend colqwen` (`vidore/colqwen2-v1.0`, 128 dims) with a PyTorch/colpali-engine interpreter. `mlx` and `jina-mlx` are Apple Silicon-only and fail on Windows with a pointer to ColQwen. Point `CLAWGALLERY_PYTHON` at that venv (`Scripts\python.exe`) for both `vdr sync` and later `search` commands. If Hugging Face downloads stall at `Fetching 2 files: 0%`, delete the incomplete `models--vidore--colqwen2-*` cache, upgrade `huggingface_hub`, and retry. Toggle `HF_HUB_DISABLE_XET` if `cdn-lfs.huggingface.co` or xet is blocked.
+
 The inference runtime is Rust-managed but MLX/Python-based because maintained ColQwen-family late-interaction model runtimes on macOS are not currently available as a low-risk pure Rust stack. Storage remains ClawGallery's embedded SQLite multi-vector store with Rust-side MaxSim scoring.
 
 Managed Jina v5 Omni retrieval path for Apple Silicon (`jinaai/jina-embeddings-v5-omni-small-retrieval-mlx`, dimensions `1024`):

--- a/src/main.rs
+++ b/src/main.rs
@@ -665,7 +665,7 @@ fn cmd_poll(paths: &AppPaths, args: PollArgs) -> Result<()> {
                     max_retries: args.max_retries,
                     auto_start: false,
                     no_auto_start: true,
-                    backend: Some(vdr::ServeBackend::Mlx),
+                    backend: Some(vdr::default_dense_backend()),
                     host: "127.0.0.1".to_string(),
                     port: 0,
                     device: "auto".to_string(),

--- a/src/vdr/backend.rs
+++ b/src/vdr/backend.rs
@@ -1,20 +1,24 @@
-use anyhow::{Result, bail};
+use anyhow::{bail, Result};
 use clap::ValueEnum;
 
 pub(super) const DEFAULT_MLX_MODEL: &str = "qnguyen3/colqwen2.5-v0.2-mlx";
 pub(super) const DEFAULT_MLX_DIMENSIONS: usize = 128;
 pub(super) const DEFAULT_MANAGED_HOST: &str = "127.0.0.1";
+pub(super) const DEFAULT_COLQWEN_MODEL: &str = "vidore/colqwen2-v1.0";
+pub(super) const DEFAULT_COLQWEN_DIMENSIONS: usize = 128;
 const JINA_MLX_MODEL: &str = "jinaai/jina-embeddings-v5-omni-small-retrieval-mlx";
 const JINA_MLX_DIMENSIONS: usize = 1024;
 pub(super) const DEFAULT_VSPLADE_MODEL: &str = clawgallery_vdr::DEFAULT_VSPLADE_MODEL;
 pub(super) const DEFAULT_VSPLADE_DIMENSIONS: usize = clawgallery_vdr::DEFAULT_VSPLADE_DIMENSIONS;
 #[cfg(windows)]
 const WINDOWS_VSPLADE_MODEL: &str = "naver/v-splade-efficient";
+pub(super) const APPLE_ONLY_BACKEND_ERROR: &str = "the mlx and jina-mlx backends require Apple Silicon MLX; on Windows use --backend colqwen with a PyTorch/colpali-engine environment";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub(crate) enum ServeBackend {
     Mlx,
     JinaMlx,
+    Colqwen,
     Vsplade,
 }
 
@@ -22,6 +26,14 @@ pub(super) struct BackendConfig {
     pub(super) backend: ServeBackend,
     pub(super) model: String,
     pub(super) dimensions: usize,
+}
+
+pub(crate) fn default_dense_backend() -> ServeBackend {
+    if cfg!(windows) {
+        ServeBackend::Colqwen
+    } else {
+        ServeBackend::Mlx
+    }
 }
 
 pub(super) fn resolve_backend(
@@ -35,13 +47,16 @@ pub(super) fn resolve_backend(
         } else if model.is_some_and(|value| value.contains("v-splade") || value.contains("vsplade"))
         {
             ServeBackend::Vsplade
+        } else if model.is_some_and(|value| value.contains("colqwen") && !value.contains("mlx")) {
+            ServeBackend::Colqwen
         } else {
-            ServeBackend::Mlx
+            default_dense_backend()
         }
     });
     let (default_model, default_dimensions) = match backend {
         ServeBackend::Mlx => (DEFAULT_MLX_MODEL, DEFAULT_MLX_DIMENSIONS),
         ServeBackend::JinaMlx => (JINA_MLX_MODEL, JINA_MLX_DIMENSIONS),
+        ServeBackend::Colqwen => (DEFAULT_COLQWEN_MODEL, DEFAULT_COLQWEN_DIMENSIONS),
         ServeBackend::Vsplade => {
             #[cfg(windows)]
             {
@@ -66,4 +81,38 @@ pub(super) fn resolve_backend(
         model: model.to_string(),
         dimensions,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        default_dense_backend, resolve_backend, ServeBackend, APPLE_ONLY_BACKEND_ERROR,
+        DEFAULT_COLQWEN_DIMENSIONS, DEFAULT_COLQWEN_MODEL,
+    };
+
+    #[test]
+    fn apple_only_error_names_colqwen() {
+        assert!(APPLE_ONLY_BACKEND_ERROR.contains("colqwen"));
+        assert!(APPLE_ONLY_BACKEND_ERROR.contains("Apple Silicon"));
+    }
+
+    #[test]
+    fn colqwen_model_selects_colqwen_backend() {
+        let config = resolve_backend(None, Some("vidore/colqwen2-v1.0"), None).expect("backend");
+        assert_eq!(config.backend, ServeBackend::Colqwen);
+        assert_eq!(config.model, DEFAULT_COLQWEN_MODEL);
+        assert_eq!(config.dimensions, DEFAULT_COLQWEN_DIMENSIONS);
+    }
+
+    #[test]
+    fn default_dense_backend_is_platform_specific() {
+        assert_eq!(
+            default_dense_backend(),
+            if cfg!(windows) {
+                ServeBackend::Colqwen
+            } else {
+                ServeBackend::Mlx
+            }
+        );
+    }
 }

--- a/src/vdr/backend.rs
+++ b/src/vdr/backend.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use clap::ValueEnum;
 
 pub(super) const DEFAULT_MLX_MODEL: &str = "qnguyen3/colqwen2.5-v0.2-mlx";
@@ -86,8 +86,8 @@ pub(super) fn resolve_backend(
 #[cfg(test)]
 mod tests {
     use super::{
-        default_dense_backend, resolve_backend, ServeBackend, APPLE_ONLY_BACKEND_ERROR,
-        DEFAULT_COLQWEN_DIMENSIONS, DEFAULT_COLQWEN_MODEL,
+        APPLE_ONLY_BACKEND_ERROR, DEFAULT_COLQWEN_DIMENSIONS, DEFAULT_COLQWEN_MODEL, ServeBackend,
+        default_dense_backend, resolve_backend,
     };
 
     #[test]

--- a/src/vdr/mod.rs
+++ b/src/vdr/mod.rs
@@ -12,8 +12,8 @@ use std::{collections::HashMap, env, path::PathBuf};
 mod backend;
 mod serve;
 
-pub(crate) use backend::ServeBackend;
 use backend::{DEFAULT_MANAGED_HOST, resolve_backend};
+pub(crate) use backend::{ServeBackend, default_dense_backend};
 pub(crate) use clawgallery_vdr::SimilarImageGroup;
 pub(crate) use clawgallery_vdr::{
     DEFAULT_DIMENSIONS, DEFAULT_MAX_RETRIES, DEFAULT_VDR_MODEL, latest_dense_index_config,
@@ -221,7 +221,7 @@ fn format_channel(name: &str, channel: &clawgallery_vdr::IndexChannelStatus) -> 
 fn encoding_for(backend: ServeBackend) -> VectorEncoding {
     match backend {
         ServeBackend::Vsplade => VectorEncoding::Sparse,
-        ServeBackend::Mlx | ServeBackend::JinaMlx => VectorEncoding::Dense,
+        ServeBackend::Mlx | ServeBackend::JinaMlx | ServeBackend::Colqwen => VectorEncoding::Dense,
     }
 }
 
@@ -238,7 +238,10 @@ pub(crate) fn embedding_search_hits(
         if skip_empty_index {
             return Ok(Vec::new());
         }
-        bail!("no dense VDR index; run `clawgallery vdr sync --backend mlx`");
+        bail!(
+            "no dense VDR index; run `clawgallery vdr sync --backend {}`",
+            if cfg!(windows) { "colqwen" } else { "mlx" }
+        );
     };
     let model = index.model;
     let dimensions = index.dimensions;

--- a/src/vdr/serve.rs
+++ b/src/vdr/serve.rs
@@ -376,8 +376,6 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn colqwen_runtime_check_does_not_require_vsplade_repo() {
-        env::remove_var("CLAWGALLERY_VSPLADE_REPO");
-        env::remove_var("CLAWGALLERY_VDR_COLQWEN_FAKE");
         let python = PathBuf::from("python");
         let err = check_python_runtime(ServeBackend::Colqwen, &python)
             .expect_err("colqwen check should fail on missing colpali imports, not vsplade repo");

--- a/src/vdr/serve.rs
+++ b/src/vdr/serve.rs
@@ -349,7 +349,7 @@ mod tests {
     use super::{default_python, virtual_env_python};
     use std::fs;
     #[cfg(windows)]
-    use std::{env, path::PathBuf};
+    use std::path::PathBuf;
 
     #[test]
     fn virtual_env_python_uses_platform_layout() {

--- a/src/vdr/serve.rs
+++ b/src/vdr/serve.rs
@@ -1,4 +1,4 @@
-use super::backend::ServeBackend;
+use super::backend::{APPLE_ONLY_BACKEND_ERROR, ServeBackend};
 use anyhow::{Context, Result, bail};
 use serde_json::json;
 use std::{
@@ -12,6 +12,7 @@ use std::{
 
 const MLX_SERVER: &str = include_str!("../../scripts/mlx_embeddings_server.py");
 const JINA_MLX_SERVER: &str = include_str!("../../scripts/jina_mlx_embeddings_server.py");
+const COLQWEN_SERVER: &str = include_str!("../../scripts/colqwen2_server.py");
 const VSPLADE_SERVER: &str = include_str!("../../scripts/vsplade_server.py");
 const VSPLADE_TORCH_SERVER: &str = include_str!("../../scripts/vsplade_torch_server.py");
 const MANAGED_STARTUP_TIMEOUT: Duration = Duration::from_secs(20 * 60);
@@ -21,6 +22,7 @@ impl ServeBackend {
         match self {
             Self::Mlx => "mlx",
             Self::JinaMlx => "jina-mlx",
+            Self::Colqwen => "colqwen",
             Self::Vsplade => "vsplade",
         }
     }
@@ -29,6 +31,7 @@ impl ServeBackend {
         match self {
             Self::Mlx => MLX_SERVER,
             Self::JinaMlx => JINA_MLX_SERVER,
+            Self::Colqwen => COLQWEN_SERVER,
             Self::Vsplade => {
                 if cfg!(windows) {
                     VSPLADE_TORCH_SERVER
@@ -237,13 +240,44 @@ fn default_python() -> PathBuf {
     PathBuf::from("python3")
 }
 
+fn fake_env_enabled(name: &str) -> bool {
+    env::var_os(name).is_some_and(|value| value == "1")
+}
+
 fn check_python_runtime(backend: ServeBackend, python: &PathBuf) -> Result<()> {
-    if backend != ServeBackend::Vsplade
-        || env::var_os("CLAWGALLERY_VDR_VSPLADE_FAKE").is_some_and(|value| value == "1")
+    let apple_only_fake = match backend {
+        ServeBackend::Mlx => fake_env_enabled("CLAWGALLERY_VDR_MLX_FAKE"),
+        ServeBackend::JinaMlx => fake_env_enabled("CLAWGALLERY_VDR_JINA_MLX_FAKE"),
+        ServeBackend::Colqwen | ServeBackend::Vsplade => false,
+    };
+    if cfg!(windows)
+        && matches!(backend, ServeBackend::Mlx | ServeBackend::JinaMlx)
+        && !apple_only_fake
     {
+        bail!("{APPLE_ONLY_BACKEND_ERROR}");
+    }
+    let (import, fake) = match backend {
+        ServeBackend::Colqwen => (
+            "import colpali_engine, torch, PIL",
+            fake_env_enabled("CLAWGALLERY_VDR_COLQWEN_FAKE"),
+        ),
+        ServeBackend::Vsplade => (
+            if cfg!(windows) {
+                "import torch, transformers, PIL"
+            } else {
+                "import splade_mlx"
+            },
+            fake_env_enabled("CLAWGALLERY_VDR_VSPLADE_FAKE"),
+        ),
+        ServeBackend::Mlx | ServeBackend::JinaMlx => return Ok(()),
+    };
+    if fake {
         return Ok(());
     }
-    if cfg!(windows) && env::var_os("CLAWGALLERY_VSPLADE_REPO").is_none() {
+    if backend == ServeBackend::Vsplade
+        && cfg!(windows)
+        && env::var_os("CLAWGALLERY_VSPLADE_REPO").is_none()
+    {
         bail!(
             "V-SPLADE Windows runtime is not configured: set \
 CLAWGALLERY_VSPLADE_REPO to a checkout of https://github.com/naver/v-splade \
@@ -252,22 +286,30 @@ before retrying with --python {} or CLAWGALLERY_PYTHON={}",
             python.display()
         );
     }
-    let import = if cfg!(windows) {
-        "import torch, transformers, PIL"
-    } else {
-        "import splade_mlx"
-    };
     let output = Command::new(python)
         .args(["-c", import])
         .output()
         .with_context(|| {
             format!(
-                "failed to inspect V-SPLADE Python runtime {}",
+                "failed to inspect {} Python runtime {}",
+                backend.name(),
                 python.display()
             )
         })?;
     if output.status.success() {
         return Ok(());
+    }
+    if backend == ServeBackend::Colqwen {
+        bail!(
+            "ColQwen runtime is unavailable in {}: could not import colpali_engine, torch, and PIL. \
+Install the Windows PyTorch runtime in this environment, then retry with \
+--python {} or CLAWGALLERY_PYTHON={}. \
+Example: {} -m pip install colpali-engine torch transformers pillow huggingface_hub",
+            python.display(),
+            python.display(),
+            python.display(),
+            python.display()
+        );
     }
     bail!(
         "V-SPLADE runtime is unavailable in {}: the selected interpreter cannot \

--- a/src/vdr/serve.rs
+++ b/src/vdr/serve.rs
@@ -344,8 +344,12 @@ fn is_loopback_host(host: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(windows)]
+    use super::{ServeBackend, check_python_runtime};
     use super::{default_python, virtual_env_python};
     use std::fs;
+    #[cfg(windows)]
+    use std::{env, path::PathBuf};
 
     #[test]
     fn virtual_env_python_uses_platform_layout() {
@@ -366,6 +370,25 @@ mod tests {
         assert_eq!(
             default_python().file_name().expect("python filename"),
             if cfg!(windows) { "python" } else { "python3" }
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn colqwen_runtime_check_does_not_require_vsplade_repo() {
+        env::remove_var("CLAWGALLERY_VSPLADE_REPO");
+        env::remove_var("CLAWGALLERY_VDR_COLQWEN_FAKE");
+        let python = PathBuf::from("python");
+        let err = check_python_runtime(ServeBackend::Colqwen, &python)
+            .expect_err("colqwen check should fail on missing colpali imports, not vsplade repo");
+        let msg = format!("{err:#}");
+        assert!(
+            !msg.contains("CLAWGALLERY_VSPLADE_REPO"),
+            "colqwen must not demand V-SPLADE_REPO, got: {msg}"
+        );
+        assert!(
+            msg.contains("ColQwen") || msg.contains("colpali"),
+            "expected ColQwen import diagnostic, got: {msg}"
         );
     }
 }

--- a/tests/colqwen_server_http.rs
+++ b/tests/colqwen_server_http.rs
@@ -1,0 +1,181 @@
+use std::{
+    fs,
+    io::{BufRead, BufReader, Read, Write},
+    net::{Shutdown, TcpListener, TcpStream},
+    path::PathBuf,
+    process::{Child, Command, Stdio},
+};
+
+fn python_interpreter() -> String {
+    std::env::var("PYTHON").unwrap_or_else(|_| {
+        if cfg!(windows) {
+            "python".to_string()
+        } else {
+            "python3".to_string()
+        }
+    })
+}
+
+struct ColqwenServer {
+    child: Child,
+    port: u16,
+}
+
+impl ColqwenServer {
+    fn start() -> Self {
+        let port = TcpListener::bind(("127.0.0.1", 0))
+            .expect("ephemeral port")
+            .local_addr()
+            .expect("local address")
+            .port();
+        let script = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("scripts/colqwen2_server.py");
+        let python = python_interpreter();
+        let mut child = Command::new(python)
+            .env("CLAWGALLERY_VDR_COLQWEN_FAKE", "1")
+            .arg(script)
+            .args(["--port", &port.to_string(), "--dimensions", "128"])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .expect("ColQwen server should start");
+        let stdout = child.stdout.take().expect("server stdout");
+        let mut ready = String::new();
+        BufReader::new(stdout)
+            .read_line(&mut ready)
+            .expect("server readiness line");
+        assert!(ready.contains("\"backend\": \"colqwen\""), "got: {ready}");
+        assert!(ready.contains("\"fake\": true"), "got: {ready}");
+        Self { child, port }
+    }
+
+    fn send(&self, content_type: &str, origin: Option<&str>, body: &str) -> String {
+        let mut stream =
+            TcpStream::connect(("127.0.0.1", self.port)).expect("server should accept requests");
+        let origin_header = origin
+            .map(|value| format!("Origin: {value}\r\n"))
+            .unwrap_or_default();
+        write!(
+            stream,
+            "POST /embed HTTP/1.0\r\nHost: 127.0.0.1:{}\r\nContent-Type: {}\r\n{}Content-Length: {}\r\n\r\n{}",
+            self.port,
+            content_type,
+            origin_header,
+            body.len(),
+            body
+        )
+        .expect("request should write");
+        stream.shutdown(Shutdown::Write).expect("request shutdown");
+        let mut response = String::new();
+        stream
+            .read_to_string(&mut response)
+            .expect("response should read");
+        response
+    }
+}
+
+impl Drop for ColqwenServer {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+#[test]
+fn colqwen_server_embeds_image_text_and_caption_inputs() {
+    // Given: the fake ColQwen dense server.
+    let server = ColqwenServer::start();
+    let temp = tempfile::tempdir().expect("tempdir");
+    let image = temp.path().join("dog.png");
+    fs::write(&image, b"png-bytes").expect("image");
+
+    // When: image, text, and caption inputs are embedded together.
+    let body = format!(
+        r#"{{"model":"vidore/colqwen2-v1.0","dimensions":128,"inputs":[{{"kind":"image","role":"document","value":"{}"}},{{"kind":"text","role":"query","value":"dog"}},{{"kind":"caption","role":"document","value":"a puppy"}}]}}"#,
+        image.display()
+    );
+    let response = server.send("application/json", None, &body);
+
+    // Then: one 128-d multi-vector is returned per input.
+    assert!(response.starts_with("HTTP/1.0 200"), "got: {response}");
+    let json_start = response.find('{').expect("json body");
+    let payload: serde_json::Value =
+        serde_json::from_str(&response[json_start..]).expect("embed json");
+    assert_eq!(payload["model"], "vidore/colqwen2-v1.0");
+    assert_eq!(payload["dimensions"], 128);
+    let embeddings = payload["embeddings"].as_array().expect("embeddings");
+    assert_eq!(embeddings.len(), 3);
+    for embedding in embeddings {
+        let rows = embedding.as_array().expect("multivector");
+        assert!(!rows.is_empty());
+        assert_eq!(rows[0].as_array().expect("row").len(), 128);
+    }
+}
+
+#[test]
+fn colqwen_server_rejects_model_and_dimension_mismatch() {
+    let server = ColqwenServer::start();
+    let model = server.send(
+        "application/json",
+        None,
+        r#"{"model":"wrong-model","dimensions":128,"inputs":[]}"#,
+    );
+    let dimensions = server.send(
+        "application/json",
+        None,
+        r#"{"model":"vidore/colqwen2-v1.0","dimensions":64,"inputs":[]}"#,
+    );
+    assert!(model.starts_with("HTTP/1.0 400"), "got: {model}");
+    assert!(model.contains("\"error\""), "got: {model}");
+    assert!(dimensions.starts_with("HTTP/1.0 400"), "got: {dimensions}");
+    assert!(dimensions.contains("\"error\""), "got: {dimensions}");
+}
+
+#[test]
+fn colqwen_server_returns_json_for_malformed_requests() {
+    let server = ColqwenServer::start();
+    let response = server.send("application/json", None, "{");
+    assert!(response.starts_with("HTTP/1.0 400"), "got: {response}");
+    assert!(response.contains("\"error\""), "got: {response}");
+}
+
+#[test]
+fn colqwen_server_rejects_cross_origin_requests() {
+    let server = ColqwenServer::start();
+    let response = server.send(
+        "application/json",
+        Some("https://attacker.example"),
+        r#"{"inputs":[{"kind":"image","role":"query","value":"/etc/passwd"}]}"#,
+    );
+    assert!(response.starts_with("HTTP/1.0 403"), "got: {response}");
+    assert!(response.contains("\"error\""), "got: {response}");
+}
+
+#[test]
+fn colqwen_incomplete_hf_cache_is_diagnosed_before_model_load() {
+    // Given: an incomplete Hugging Face snapshot with no weights.
+    let temp = tempfile::tempdir().expect("tempdir");
+    let snapshot = temp
+        .path()
+        .join("hub/models--vidore--colqwen2-v1.0/snapshots/deadbeef");
+    fs::create_dir_all(&snapshot).expect("snapshot dir");
+    fs::write(snapshot.join("adapter_config.json"), b"{}").expect("adapter config");
+    let script = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("scripts/colqwen2_server.py");
+    let python = python_interpreter();
+
+    // When: the real (non-fake) server starts against that cache.
+    let output = Command::new(python)
+        .env("HF_HOME", temp.path())
+        .env_remove("CLAWGALLERY_VDR_COLQWEN_FAKE")
+        .arg(script)
+        .args(["--port", "0"])
+        .output()
+        .expect("colqwen server should run");
+
+    // Then: startup fails with an actionable incomplete-download diagnostic.
+    assert!(!output.status.success(), "incomplete cache should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("incomplete") && stderr.contains("HF_HUB_DISABLE_XET"),
+        "got: {stderr}"
+    );
+}

--- a/tests/jina_mlx_server_http.rs
+++ b/tests/jina_mlx_server_http.rs
@@ -21,7 +21,14 @@ impl JinaServer {
             .port();
         let script =
             PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("scripts/jina_mlx_embeddings_server.py");
-        let mut child = Command::new("python3")
+        let python = std::env::var("PYTHON").unwrap_or_else(|_| {
+            if cfg!(windows) {
+                "python".to_string()
+            } else {
+                "python3".to_string()
+            }
+        });
+        let mut child = Command::new(python)
             .env("CLAWGALLERY_VDR_JINA_MLX_FAKE", "1")
             .arg(script)
             .args(["--port", &port.to_string()])

--- a/tests/vdr_auto_start_cli.rs
+++ b/tests/vdr_auto_start_cli.rs
@@ -107,6 +107,58 @@ fn embedding_search_auto_starts_jina_backend_from_index_model() {
 }
 
 #[test]
+fn vdr_plain_sync_colqwen_fake_auto_starts_with_backend_defaults() {
+    // Given: one indexed image and only the managed ColQwen backend selection.
+    let (_temp, config) = one_image_library();
+    let python = python_for_mlx_tests();
+
+    // When: sync runs without an external embedding server or explicit model dimensions.
+    let synced = assert_success(run_without_embedding_url(
+        &config,
+        &["vdr", "sync", "--backend", "colqwen", "--python", &python],
+        Some("CLAWGALLERY_VDR_COLQWEN_FAKE"),
+    ));
+    let status = assert_success(run_without_embedding_url(
+        &config,
+        &["vdr", "status", "--json"],
+        None,
+    ));
+
+    // Then: the managed ColQwen runtime starts and its exact index contract is persisted.
+    assert!(
+        synced.contains("starting managed colqwen embedding server at http://127.0.0.1:"),
+        "managed ColQwen server startup should be observable, got: {synced}"
+    );
+    assert!(synced.contains("indexed 1"), "got: {synced}");
+    let status: serde_json::Value = serde_json::from_str(&status).expect("status json");
+    assert_eq!(status["model"], "vidore/colqwen2-v1.0");
+    assert_eq!(status["dimensions"], 128);
+    assert_eq!(status["dense"]["available"], true);
+}
+
+#[test]
+fn embedding_search_auto_starts_colqwen_backend_from_index_model() {
+    // Given: an image index created by the managed ColQwen backend.
+    let (_temp, config) = one_image_library();
+    let python = python_for_mlx_tests();
+    assert_success(run_without_embedding_url(
+        &config,
+        &["vdr", "sync", "--backend", "colqwen", "--python", &python],
+        Some("CLAWGALLERY_VDR_COLQWEN_FAKE"),
+    ));
+
+    // When: embedding search runs without restating a backend or endpoint.
+    let search = assert_success(run_without_embedding_url(
+        &config,
+        &["search", "--mode", "embedding", "dog", "--json"],
+        Some("CLAWGALLERY_VDR_COLQWEN_FAKE"),
+    ));
+
+    // Then: the persisted model selects ColQwen and returns the indexed image.
+    assert!(search.contains("dog.png"), "got: {search}");
+}
+
+#[test]
 fn vdr_auto_start_skips_managed_server_when_nothing_changed() {
     let server = FakeEmbeddingServer::start();
     let (temp, config) = one_image_library();

--- a/tests/vdr_auto_start_edges_cli.rs
+++ b/tests/vdr_auto_start_edges_cli.rs
@@ -93,6 +93,7 @@ fn vdr_auto_start_missing_python_path_fails_cleanly() {
     );
 }
 
+#[cfg(unix)]
 #[test]
 #[cfg(unix)]
 fn vdr_vsplade_missing_runtime_fails_with_actionable_diagnostic() {

--- a/tests/vdr_cli.rs
+++ b/tests/vdr_cli.rs
@@ -1142,7 +1142,14 @@ fn embedding_search_without_dense_index_fails_before_query_embedding() {
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("no dense VDR index"), "got: {stderr}");
-    assert!(stderr.contains("vdr sync --backend mlx"), "got: {stderr}");
+    assert!(
+        stderr.contains(if cfg!(windows) {
+            "vdr sync --backend colqwen"
+        } else {
+            "vdr sync --backend mlx"
+        }),
+        "got: {stderr}"
+    );
     assert_eq!(
         server.request_count(),
         before,
@@ -1193,7 +1200,14 @@ fn sparse_only_library_rejects_embedding_mode_and_accepts_lexical() {
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("no dense VDR index"), "got: {stderr}");
-    assert!(stderr.contains("vdr sync --backend mlx"), "got: {stderr}");
+    assert!(
+        stderr.contains(if cfg!(windows) {
+            "vdr sync --backend colqwen"
+        } else {
+            "vdr sync --backend mlx"
+        }),
+        "got: {stderr}"
+    );
     assert_eq!(
         server.request_count(),
         after_sync,

--- a/tests/vdr_serve_cli.rs
+++ b/tests/vdr_serve_cli.rs
@@ -61,6 +61,24 @@ fn vdr_serve_help_lists_vsplade_backend() {
 }
 
 #[test]
+fn vdr_serve_help_lists_colqwen_backend() {
+    // Given: the installed ClawGallery binary.
+    let temp = tempfile::tempdir().expect("tempdir");
+
+    // When: the managed VDR server help is requested.
+    let output = Command::new(clawgallery_bin())
+        .env("CLAWGALLERY_CONFIG_DIR", temp.path().join("state"))
+        .args(["vdr", "serve", "--help"])
+        .output()
+        .expect("clawgallery command should run");
+
+    // Then: the Windows dense ColQwen backend is discoverable.
+    assert!(output.status.success(), "serve help should succeed");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("colqwen"), "got: {stdout}");
+}
+
+#[test]
 fn vdr_serve_jina_mlx_rejects_incompatible_dimensions() {
     // Given: the Jina MLX backend with a ColQwen-sized vector request.
     let temp = tempfile::tempdir().expect("tempdir");
@@ -148,5 +166,75 @@ fn vdr_serve_mlx_accepts_allow_remote_flag_for_python_launcher() {
         "serve help with --allow-remote should succeed\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn vdr_serve_colqwen_rejects_remote_bind_without_allow_remote() {
+    // Given: a request to expose the unauthenticated ColQwen embedding server.
+    let temp = tempfile::tempdir().expect("tempdir");
+
+    // When: the colqwen backend is started on a non-loopback host without an opt-in.
+    let output = Command::new(clawgallery_bin())
+        .env("CLAWGALLERY_CONFIG_DIR", temp.path().join("state"))
+        .env("CLAWGALLERY_VDR_COLQWEN_FAKE", "1")
+        .args([
+            "vdr",
+            "serve",
+            "--backend",
+            "colqwen",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            "8878",
+        ])
+        .output()
+        .expect("clawgallery command should run");
+
+    // Then: the launcher refuses the unsafe bind before starting the daemon.
+    assert!(
+        !output.status.success(),
+        "remote bind should fail\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("refusing to bind") && stderr.contains("non-loopback"),
+        "expected non-loopback refusal, got: {stderr}"
+    );
+}
+
+#[cfg(windows)]
+#[test]
+fn vdr_serve_mlx_on_windows_points_at_colqwen() {
+    // Given: the Windows CLI with mlx selected and no MLX fake runtime.
+    let temp = tempfile::tempdir().expect("tempdir");
+
+    // When: a user asks the managed mlx backend to start.
+    let output = Command::new(clawgallery_bin())
+        .env("CLAWGALLERY_CONFIG_DIR", temp.path().join("state"))
+        .env_remove("CLAWGALLERY_VDR_MLX_FAKE")
+        .args([
+            "vdr",
+            "serve",
+            "--backend",
+            "mlx",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            "0",
+        ])
+        .output()
+        .expect("clawgallery command should run");
+
+    // Then: Windows fails before importing mlx_embeddings and names --backend colqwen.
+    assert!(!output.status.success(), "mlx on Windows should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("colqwen"), "got: {stderr}");
+    assert!(stderr.contains("Apple Silicon"), "got: {stderr}");
+    assert!(
+        !stderr.contains("mlx_embeddings"),
+        "should not reach the Apple-only import, got: {stderr}"
     );
 }


### PR DESCRIPTION
## Summary

Closes #25.

- Promote `scripts/colqwen2_server.py` to managed `--backend colqwen` (`vidore/colqwen2-v1.0`, 128 dims) for Windows CPU/CUDA PyTorch + colpali-engine.
- Default dense VDR to ColQwen on Windows; keep MLX as the macOS/Linux default.
- Reject real `mlx` / `jina-mlx` on Windows before importing `mlx_embeddings`, with a pointer to `--backend colqwen`.
- Diagnose incomplete Hugging Face snapshots before model load. Do not force `HF_HUB_DISABLE_XET=1` on Windows; this host cannot resolve `cdn-lfs.huggingface.co`, and xet succeeds.
- Document Windows install, add ColQwen HTTP/auto-start tests, and add a Windows CI job. Unix-only tests are `cfg(unix)` so that job can compile.

## Test plan

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `python3 -m py_compile scripts/colqwen2_server.py`
- Fake ColQwen `/embed` contract: image/text/caption, model/dim mismatch, malformed JSON, origin 403, incomplete cache diagnostic
- SSH Windows 11 (`DESKTOP-4N2OLO3`):
  - RED on 0.2.2: `vdr sync --backend mlx` → `ModuleNotFoundError: mlx_embeddings`
  - GREEN: `vdr sync --backend mlx` → Apple Silicon / `--backend colqwen` diagnostic, exit 1
  - GREEN: `vdr sync --backend colqwen` indexed 1 vector
  - GREEN: `vdr status --json` dense available, model `vidore/colqwen2-v1.0`, dimensions 128
  - GREEN: `search --mode embedding lobster --json` hit `clawgallery-hero.jpg` score 0.758
  - GREEN: hybrid search returned the same image (`used_channels: keyword,embedding`, lexical skipped)