### PR TITLE
fix(daemon): use Task Scheduler for the Windows daemon

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use std::{
     fs::{self, File},
     io,
     path::{Path, PathBuf},
-    process::{Command as ProcessCommand, ExitCode},
+    process::{Command as ProcessCommand, ExitCode, Stdio},
     thread,
     time::Duration,
 };
@@ -1215,41 +1215,67 @@ fn cmd_daemon(paths: &AppPaths, args: DaemonArgs) -> Result<()> {
 }
 
 fn cmd_daemon_install(paths: &AppPaths, args: DaemonPollArgs) -> Result<()> {
-    let service_file = daemon_service_file()?;
-    if let Some(parent) = service_file.parent() {
-        fs::create_dir_all(parent)?;
-    }
     let exe = env::current_exe().context("failed to resolve current executable")?;
     let arguments = daemon_run_arguments(&exe, &args);
     let environment = daemon_environment(paths);
-    let label = daemon_label();
-    let content = if service_file.extension().and_then(OsStr::to_str) == Some("service") {
-        systemd_service(paths, &arguments, &environment)
-    } else {
-        launchd_plist(paths, &label, &arguments, &environment)
-    };
-    fs::write(&service_file, content)
-        .with_context(|| format!("failed to write {}", service_file.display()))?;
-    println!("installed daemon service {}", service_file.display());
+    match daemon_service()? {
+        DaemonService::File(service_file) => {
+            if let Some(parent) = service_file.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            let label = daemon_label();
+            let content = if service_file.extension().and_then(OsStr::to_str) == Some("service") {
+                systemd_service(paths, &arguments, &environment)
+            } else {
+                launchd_plist(paths, &label, &arguments, &environment)
+            };
+            fs::write(&service_file, content)
+                .with_context(|| format!("failed to write {}", service_file.display()))?;
+            println!("installed daemon service {}", service_file.display());
+        }
+        DaemonService::WindowsTask(name) => {
+            let wrapper = daemon_windows_wrapper_path(paths);
+            if let Some(parent) = wrapper.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            fs::write(
+                &wrapper,
+                daemon_windows_wrapper(&daemon_log_path(paths), &arguments, &environment),
+            )
+            .with_context(|| format!("failed to write {}", wrapper.display()))?;
+            let create_args = daemon_windows_task_create_args(&name, &wrapper);
+            let create_args = create_args.iter().map(String::as_str).collect::<Vec<_>>();
+            run_status_command("schtasks", &create_args)
+                .context("failed to register daemon scheduled task")?;
+            println!("installed daemon service {name} (Task Scheduler)");
+        }
+    }
     println!("logs: {}", daemon_log_path(paths).display());
     Ok(())
 }
 
 fn cmd_daemon_start(paths: &AppPaths) -> Result<()> {
-    let service_file = daemon_service_file()?;
-    if env::var_os(DAEMON_DIR_ENV).is_some() {
-        println!(
-            "start skipped for managed test service {}",
-            service_file.display()
-        );
-        return Ok(());
-    }
-    if service_file.extension().and_then(OsStr::to_str) == Some("service") {
-        let service_name = daemon_systemd_unit_name(&service_file)?;
-        run_status_command("systemctl", &["--user", "start", service_name.as_str()])?;
-    } else {
-        let service = service_file.to_string_lossy().to_string();
-        run_status_command("launchctl", &["load", service.as_str()])?;
+    match daemon_service()? {
+        DaemonService::File(service_file) => {
+            if env::var_os(DAEMON_DIR_ENV).is_some() {
+                println!(
+                    "start skipped for managed test service {}",
+                    service_file.display()
+                );
+                return Ok(());
+            }
+            if service_file.extension().and_then(OsStr::to_str) == Some("service") {
+                let service_name = daemon_systemd_unit_name(&service_file)?;
+                run_status_command("systemctl", &["--user", "start", service_name.as_str()])?;
+            } else {
+                let service = service_file.to_string_lossy().to_string();
+                run_status_command("launchctl", &["load", service.as_str()])?;
+            }
+        }
+        DaemonService::WindowsTask(name) => {
+            run_status_command("schtasks", &["/Run", "/TN", name.as_str()])
+                .context("failed to start daemon scheduled task")?;
+        }
     }
     println!("started daemon service");
     println!("logs: {}", daemon_log_path(paths).display());
@@ -1257,32 +1283,53 @@ fn cmd_daemon_start(paths: &AppPaths) -> Result<()> {
 }
 
 fn cmd_daemon_stop(_paths: &AppPaths) -> Result<()> {
-    let service_file = daemon_service_file()?;
-    if env::var_os(DAEMON_DIR_ENV).is_some() {
-        println!(
-            "stop skipped for managed test service {}",
-            service_file.display()
-        );
-        return Ok(());
-    }
-    if service_file.extension().and_then(OsStr::to_str) == Some("service") {
-        let service_name = daemon_systemd_unit_name(&service_file)?;
-        run_status_command("systemctl", &["--user", "stop", service_name.as_str()])?;
-    } else {
-        let service = service_file.to_string_lossy().to_string();
-        run_status_command("launchctl", &["unload", service.as_str()])?;
+    match daemon_service()? {
+        DaemonService::File(service_file) => {
+            if env::var_os(DAEMON_DIR_ENV).is_some() {
+                println!(
+                    "stop skipped for managed test service {}",
+                    service_file.display()
+                );
+                return Ok(());
+            }
+            if service_file.extension().and_then(OsStr::to_str) == Some("service") {
+                let service_name = daemon_systemd_unit_name(&service_file)?;
+                run_status_command("systemctl", &["--user", "stop", service_name.as_str()])?;
+            } else {
+                let service = service_file.to_string_lossy().to_string();
+                run_status_command("launchctl", &["unload", service.as_str()])?;
+            }
+        }
+        DaemonService::WindowsTask(name) => {
+            run_status_command("schtasks", &["/End", "/TN", name.as_str()])
+                .context("failed to stop daemon scheduled task")?;
+        }
     }
     println!("stopped daemon service");
     Ok(())
 }
 
 fn cmd_daemon_status(paths: &AppPaths) -> Result<()> {
-    let service_file = daemon_service_file()?;
-    println!(
-        "installed: {}",
-        if service_file.exists() { "yes" } else { "no" }
-    );
-    println!("service_file: {}", service_file.display());
+    match daemon_service()? {
+        DaemonService::File(service_file) => {
+            println!(
+                "installed: {}",
+                if service_file.exists() { "yes" } else { "no" }
+            );
+            println!("service_file: {}", service_file.display());
+        }
+        DaemonService::WindowsTask(name) => {
+            println!(
+                "installed: {}",
+                if windows_task_exists(&name) {
+                    "yes"
+                } else {
+                    "no"
+                }
+            );
+            println!("task: {name} (Task Scheduler)");
+        }
+    }
     println!("logs: {}", daemon_log_path(paths).display());
     match read_daemon_state(paths)? {
         Some(state) => {
@@ -1298,13 +1345,26 @@ fn cmd_daemon_status(paths: &AppPaths) -> Result<()> {
 }
 
 fn cmd_daemon_uninstall(paths: &AppPaths) -> Result<()> {
-    let service_file = daemon_service_file()?;
-    if service_file.exists() {
-        fs::remove_file(&service_file)
-            .with_context(|| format!("failed to remove {}", service_file.display()))?;
-        println!("uninstalled daemon service {}", service_file.display());
-    } else {
-        println!("daemon service was not installed");
+    match daemon_service()? {
+        DaemonService::File(service_file) => {
+            if service_file.exists() {
+                fs::remove_file(&service_file)
+                    .with_context(|| format!("failed to remove {}", service_file.display()))?;
+                println!("uninstalled daemon service {}", service_file.display());
+            } else {
+                println!("daemon service was not installed");
+            }
+        }
+        DaemonService::WindowsTask(name) => {
+            if windows_task_exists(&name) {
+                run_status_command("schtasks", &["/Delete", "/F", "/TN", name.as_str()])
+                    .context("failed to delete daemon scheduled task")?;
+                println!("uninstalled daemon service {name}");
+            } else {
+                println!("daemon service was not installed");
+            }
+            let _ = fs::remove_file(daemon_windows_wrapper_path(paths));
+        }
     }
     let _ = fs::remove_file(daemon_pid_path(paths));
     Ok(())
@@ -1421,20 +1481,88 @@ fn systemd_service(
     )
 }
 
-fn daemon_service_file() -> Result<PathBuf> {
+enum DaemonService {
+    File(PathBuf),
+    WindowsTask(String),
+}
+
+fn daemon_service() -> Result<DaemonService> {
     if let Some(dir) = env::var_os(DAEMON_DIR_ENV) {
-        return Ok(PathBuf::from(dir).join(format!("{}.plist", daemon_label())));
+        return Ok(DaemonService::File(
+            PathBuf::from(dir).join(format!("{}.plist", daemon_label())),
+        ));
+    }
+    if cfg!(target_os = "windows") {
+        return Ok(DaemonService::WindowsTask(daemon_label()));
     }
     if cfg!(target_os = "linux") {
         let dir = dirs::config_dir()
             .ok_or_else(|| anyhow!("could not resolve config directory"))?
             .join("systemd/user");
-        return Ok(dir.join(format!("{}.service", daemon_label())));
+        return Ok(DaemonService::File(
+            dir.join(format!("{}.service", daemon_label())),
+        ));
     }
     let dir = dirs::home_dir()
         .ok_or_else(|| anyhow!("could not resolve home directory"))?
         .join("Library/LaunchAgents");
-    Ok(dir.join(format!("{}.plist", daemon_label())))
+    Ok(DaemonService::File(
+        dir.join(format!("{}.plist", daemon_label())),
+    ))
+}
+
+fn daemon_windows_wrapper_path(paths: &AppPaths) -> PathBuf {
+    paths.root.join("clawgallery-daemon.cmd")
+}
+
+fn daemon_windows_wrapper(
+    log_path: &Path,
+    arguments: &[String],
+    environment: &[(String, String)],
+) -> String {
+    let mut lines = vec!["@echo off".to_string()];
+    for (key, value) in environment {
+        lines.push(format!("set \"{}={}\"", key, cmd_escape(value)));
+    }
+    let command = arguments
+        .iter()
+        .map(|value| format!("\"{}\"", cmd_escape(value)))
+        .collect::<Vec<_>>()
+        .join(" ");
+    lines.push(format!(
+        "{command} >> \"{}\" 2>&1",
+        cmd_escape(&log_path.display().to_string())
+    ));
+    lines.push(String::new());
+    lines.join("\r\n")
+}
+
+fn daemon_windows_task_create_args(name: &str, wrapper: &Path) -> Vec<String> {
+    vec![
+        "/Create".to_string(),
+        "/F".to_string(),
+        "/SC".to_string(),
+        "ONLOGON".to_string(),
+        "/TN".to_string(),
+        name.to_string(),
+        "/TR".to_string(),
+        format!("\"{}\"", wrapper.display()),
+    ]
+}
+
+fn windows_task_exists(name: &str) -> bool {
+    ProcessCommand::new("schtasks")
+        .args(["/Query", "/TN", name])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
+fn cmd_escape(value: &str) -> String {
+    value.replace('%', "%%")
 }
 
 fn daemon_label() -> String {
@@ -3004,6 +3132,65 @@ fn mask_api_keys(input: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn windows_wrapper_sets_environment_and_redirects_log() {
+        let wrapper = daemon_windows_wrapper(
+            Path::new("C:\\state\\daemon.log"),
+            &[
+                "C:\\bin\\clawgallery.exe".to_string(),
+                "daemon".to_string(),
+                "run".to_string(),
+                "--interval".to_string(),
+                "5".to_string(),
+            ],
+            &[
+                (
+                    "CLAWGALLERY_CONFIG_DIR".to_string(),
+                    "C:\\state".to_string(),
+                ),
+                ("OPENAI_API_KEY".to_string(), "sk-test".to_string()),
+            ],
+        );
+        assert!(wrapper.starts_with("@echo off"));
+        assert!(wrapper.contains("set \"CLAWGALLERY_CONFIG_DIR=C:\\state\""));
+        assert!(wrapper.contains("set \"OPENAI_API_KEY=sk-test\""));
+        assert!(
+            wrapper.contains("\"C:\\bin\\clawgallery.exe\" \"daemon\" \"run\" \"--interval\" \"5\" >> \"C:\\state\\daemon.log\" 2>&1"),
+            "got: {wrapper}"
+        );
+    }
+
+    #[test]
+    fn windows_wrapper_escapes_percent_for_batch_files() {
+        let wrapper = daemon_windows_wrapper(
+            Path::new("C:\\state\\daemon.log"),
+            &["clawgallery".to_string()],
+            &[("KEY".to_string(), "50%".to_string())],
+        );
+        assert!(wrapper.contains("set \"KEY=50%%\""), "got: {wrapper}");
+    }
+
+    #[test]
+    fn windows_task_create_args_register_onlogon_task() {
+        let args = daemon_windows_task_create_args(
+            "com.clawgallery.poll",
+            Path::new("C:\\state\\clawgallery-daemon.cmd"),
+        );
+        assert_eq!(
+            args,
+            vec![
+                "/Create",
+                "/F",
+                "/SC",
+                "ONLOGON",
+                "/TN",
+                "com.clawgallery.poll",
+                "/TR",
+                "\"C:\\state\\clawgallery-daemon.cmd\""
+            ]
+        );
+    }
 
     #[test]
     fn detects_supported_images_case_insensitively() {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -446,6 +446,83 @@ fn daemon_status_reports_missing_service_cleanly() {
     assert!(status.contains("installed: no"), "got: {status}");
 }
 
+#[cfg(windows)]
+fn run_with_str_env(config: &Path, args: &[&str], envs: &[(&str, &str)]) -> Output {
+    let mut command = Command::new(bin());
+    command
+        .env("CLAWGALLERY_CONFIG_DIR", config)
+        .env_remove("OPENAI_API_KEY")
+        .env("CODEX_HOME", config.join("codex-home"))
+        .args(args);
+    for (key, value) in envs {
+        command.env(key, value);
+    }
+    command.output().expect("clawgallery command should run")
+}
+
+#[cfg(windows)]
+struct ScheduledTaskGuard(String);
+
+#[cfg(windows)]
+impl Drop for ScheduledTaskGuard {
+    fn drop(&mut self) {
+        let _ = Command::new("schtasks")
+            .args(["/Delete", "/F", "/TN", &self.0])
+            .output();
+    }
+}
+
+#[cfg(windows)]
+#[test]
+fn daemon_install_status_and_uninstall_use_windows_task_scheduler() {
+    let temp = tempfile::tempdir().unwrap();
+    let config = temp.path().join("state");
+    let label = format!("ClawGalleryTestDaemon{}", std::process::id());
+    let _guard = ScheduledTaskGuard(label.clone());
+    let envs: Vec<(&str, &str)> = vec![("CLAWGALLERY_DAEMON_LABEL", label.as_str())];
+    assert_success(run(&config, &["init"]));
+
+    let installed = assert_success(run_with_str_env(
+        &config,
+        &["daemon", "install", "--interval", "5"],
+        &envs,
+    ));
+    assert!(installed.contains("Task Scheduler"), "got: {installed}");
+
+    let query = Command::new("schtasks")
+        .args(["/Query", "/TN", &label])
+        .output()
+        .unwrap();
+    assert!(query.status.success(), "scheduled task should exist");
+
+    let plist = PathBuf::from(env::var("USERPROFILE").unwrap())
+        .join("Library")
+        .join("LaunchAgents")
+        .join(format!("{label}.plist"));
+    assert!(
+        !plist.exists(),
+        "no launchd plist should be created on Windows"
+    );
+
+    let status = assert_success(run_with_str_env(&config, &["daemon", "status"], &envs));
+    assert!(status.contains("installed: yes"), "got: {status}");
+    assert!(status.contains(&label), "got: {status}");
+
+    let uninstalled = assert_success(run_with_str_env(&config, &["daemon", "uninstall"], &envs));
+    assert!(
+        uninstalled.contains("uninstalled daemon service"),
+        "got: {uninstalled}"
+    );
+    let query = Command::new("schtasks")
+        .args(["/Query", "/TN", &label])
+        .output()
+        .unwrap();
+    assert!(
+        !query.status.success(),
+        "scheduled task should be removed after uninstall"
+    );
+}
+
 #[test]
 fn caption_dry_run_output_is_terse() {
     let temp = tempfile::tempdir().unwrap();

--- a/tests/colqwen_server_http.rs
+++ b/tests/colqwen_server_http.rs
@@ -88,11 +88,18 @@ fn colqwen_server_embeds_image_text_and_caption_inputs() {
     let image = temp.path().join("dog.png");
     fs::write(&image, b"png-bytes").expect("image");
 
-    // When: image, text, and caption inputs are embedded together.
-    let body = format!(
-        r#"{{"model":"vidore/colqwen2-v1.0","dimensions":128,"inputs":[{{"kind":"image","role":"document","value":"{}"}},{{"kind":"text","role":"query","value":"dog"}},{{"kind":"caption","role":"document","value":"a puppy"}}]}}"#,
-        image.display()
-    );
+    // When: image, text, and caption inputs are embedded together. The body
+    // is built with serde_json so Windows paths with backslashes stay valid JSON.
+    let body = serde_json::json!({
+        "model": "vidore/colqwen2-v1.0",
+        "dimensions": 128,
+        "inputs": [
+            {"kind": "image", "role": "document", "value": image.display().to_string()},
+            {"kind": "text", "role": "query", "value": "dog"},
+            {"kind": "caption", "role": "document", "value": "a puppy"}
+        ]
+    })
+    .to_string();
     let response = server.send("application/json", None, &body);
 
     // Then: one 128-d multi-vector is returned per input.

--- a/tests/vdr_auto_start_edges_cli.rs
+++ b/tests/vdr_auto_start_edges_cli.rs
@@ -86,9 +86,15 @@ fn vdr_auto_start_missing_python_path_fails_cleanly() {
 
     assert!(!output.status.success(), "sync should fail");
     let stderr = String::from_utf8_lossy(&output.stderr);
+    // On Windows the default dense backend is ColQwen, so the missing
+    // interpreter is reported by the runtime inspection instead of the spawn.
+    let expected = if cfg!(windows) {
+        "failed to inspect colqwen Python runtime"
+    } else {
+        "failed to start Python interpreter"
+    };
     assert!(
-        stderr.contains("failed to start Python interpreter")
-            && stderr.contains(missing_python.to_str().expect("utf8")),
+        stderr.contains(expected) && stderr.contains(missing_python.to_str().expect("utf8")),
         "expected missing interpreter in error, got: {stderr}"
     );
 }


### PR DESCRIPTION
## Summary

On Windows, `daemon install` fell through to the macOS branch of `daemon_service_file()` and wrote `~/Library/LaunchAgents/com.clawgallery.poll.plist`, which Windows cannot consume, while `daemon status` still reported `installed: yes` (issue #20).

Daemon commands now route through a `DaemonService` enum:

- **Managed test mode** (`CLAWGALLERY_DAEMON_DIR`) and **launchd/systemd**: unchanged file-based flow.
- **Windows**: `install` writes a `clawgallery-daemon.cmd` wrapper (environment + log redirection) into the config directory and registers an `ONLOGON` task via `schtasks /Create /F`; `start`/`stop`/`status`/`uninstall` map to `schtasks /Run`, `/End`, `/Query`, `/Delete /F`. No launchd artifacts are created on Windows.

## Test plan

- [x] `cargo fmt --all -- --check` / `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --all-features` green locally (macOS): 162 passed, 0 failed — existing managed-mode daemon tests unchanged and passing
- [x] New cross-platform unit tests for the wrapper builder, percent-escaping, and schtasks argument shape
- [x] New `#[cfg(windows)]` integration test exercising install → status → uninstall against real Task Scheduler (runs on the Windows CI runner, with RAII task cleanup)
- [ ] Live QA on the maintainer's Windows 11 host (issue's original repro environment) — host is currently offline; will run the exact issue repro (`daemon install --interval 1` → `status` → `start` → `stop` → `uninstall`) and report back here once it is reachable

Closes #20

> **Note for reviewers:** this branch is currently stacked on #30 (the Windows CI test fixes) so its own Windows CI runs green; the diff will shrink to just this fix once #30 merges. Merge order: #30 first.