### PR TITLE
fix(caption): exit non-zero when a caption job fails

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -743,6 +743,7 @@ fn cmd_caption(paths: &AppPaths, args: CaptionArgs) -> Result<()> {
         return Ok(());
     }
     let provider = build_provider(&config, args.provider, args.model.clone(), args.max_retries)?;
+    let mut failures = 0usize;
     for result in bounded_concurrent_map(images, args.concurrency, |image| {
         caption_image_job(&provider, image)
     })? {
@@ -766,9 +767,13 @@ fn cmd_caption(paths: &AppPaths, args: CaptionArgs) -> Result<()> {
                 println!("captioned {}", result.image.path.display());
             }
             Err(err) => {
+                failures += 1;
                 log_error(paths, "caption", err);
             }
         }
+    }
+    if failures > 0 {
+        bail!("caption failed for {failures} image(s)");
     }
     Ok(())
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -327,6 +327,45 @@ fn caption_missing_auth_is_nonzero() {
 }
 
 #[test]
+fn caption_provider_failure_is_nonzero() {
+    let temp = tempfile::tempdir().unwrap();
+    let config = temp.path().join("state");
+    let image = temp.path().join("screen.png");
+    fs::write(&image, b"not really png").unwrap();
+    assert_success(run(&config, &["init"]));
+
+    // Given: credentials exist but every provider request fails (issue #21:
+    // a 401 from api.openai.com exited 0 because job errors were only logged).
+    let output = Command::new(bin())
+        .env("CLAWGALLERY_CONFIG_DIR", &config)
+        .env("OPENAI_API_KEY", "sk-invalid-test-key")
+        .env("OPENAI_BASE_URL", "http://127.0.0.1:1")
+        .env("CODEX_HOME", config.join("codex-home"))
+        .args([
+            "caption",
+            "--file",
+            image.to_str().unwrap(),
+            "--max-retries",
+            "0",
+        ])
+        .output()
+        .expect("clawgallery command should run");
+
+    // Then: automation observes the failure through the exit code.
+    assert!(
+        !output.status.success(),
+        "caption must exit non-zero when the provider request fails\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let captions = config.join("captions.jsonl");
+    assert!(
+        !captions.exists() || fs::read_to_string(&captions).unwrap().trim().is_empty(),
+        "no caption record should be written on failure"
+    );
+}
+
+#[test]
 fn rename_accepts_explicit_dry_run_flag() {
     let temp = tempfile::tempdir().unwrap();
     let config = temp.path().join("state");

--- a/tests/colqwen_server_http.rs
+++ b/tests/colqwen_server_http.rs
@@ -88,11 +88,18 @@ fn colqwen_server_embeds_image_text_and_caption_inputs() {
     let image = temp.path().join("dog.png");
     fs::write(&image, b"png-bytes").expect("image");
 
-    // When: image, text, and caption inputs are embedded together.
-    let body = format!(
-        r#"{{"model":"vidore/colqwen2-v1.0","dimensions":128,"inputs":[{{"kind":"image","role":"document","value":"{}"}},{{"kind":"text","role":"query","value":"dog"}},{{"kind":"caption","role":"document","value":"a puppy"}}]}}"#,
-        image.display()
-    );
+    // When: image, text, and caption inputs are embedded together. The body
+    // is built with serde_json so Windows paths with backslashes stay valid JSON.
+    let body = serde_json::json!({
+        "model": "vidore/colqwen2-v1.0",
+        "dimensions": 128,
+        "inputs": [
+            {"kind": "image", "role": "document", "value": image.display().to_string()},
+            {"kind": "text", "role": "query", "value": "dog"},
+            {"kind": "caption", "role": "document", "value": "a puppy"}
+        ]
+    })
+    .to_string();
     let response = server.send("application/json", None, &body);
 
     // Then: one 128-d multi-vector is returned per input.

--- a/tests/vdr_auto_start_edges_cli.rs
+++ b/tests/vdr_auto_start_edges_cli.rs
@@ -86,9 +86,15 @@ fn vdr_auto_start_missing_python_path_fails_cleanly() {
 
     assert!(!output.status.success(), "sync should fail");
     let stderr = String::from_utf8_lossy(&output.stderr);
+    // On Windows the default dense backend is ColQwen, so the missing
+    // interpreter is reported by the runtime inspection instead of the spawn.
+    let expected = if cfg!(windows) {
+        "failed to inspect colqwen Python runtime"
+    } else {
+        "failed to start Python interpreter"
+    };
     assert!(
-        stderr.contains("failed to start Python interpreter")
-            && stderr.contains(missing_python.to_str().expect("utf8")),
+        stderr.contains(expected) && stderr.contains(missing_python.to_str().expect("utf8")),
         "expected missing interpreter in error, got: {stderr}"
     );
 }


### PR DESCRIPTION
## Summary

`cmd_caption` swallowed per-image provider errors via `log_error` and returned `Ok(())`, so `clawgallery caption --file ...` printed an HTTP 401 yet exited with status 0 — a silent failure for scripts and the poll loop (issue #21).

Per-image caption failures are now counted and reported as an error after all images are processed, so partial successes are still persisted while the exit code reflects the failure. (The poll loop already isolates `cmd_caption` errors via `log_error(paths, "poll_caption", ...)`, so daemon behavior is unchanged apart from the error now being visible there too.)

## Test plan

- [x] New RED→GREEN test `caption_provider_failure_is_nonzero`: credentials present but every provider request fails (`OPENAI_BASE_URL=http://127.0.0.1:1`, `--max-retries 0`) — pre-fix the command exited 0 with the error only in stderr; post-fix it exits non-zero and writes no caption record
- [x] Existing `caption_missing_auth_is_nonzero` and the rest of `cargo test --all-features` green (160 passed, 0 failed) + `cargo fmt` / `clippy -D warnings` clean
- [ ] Live QA on the maintainer's Windows 11 host (issue's original repro: invalid credentials → `$LASTEXITCODE -ne 0`) — host currently offline; will report back once reachable

Closes #21

> **Note for reviewers:** this branch is currently stacked on #30 (the Windows CI test fixes) so its own Windows CI runs green; the diff will shrink to just this fix once #30 merges. Merge order: #30 first.