### PR TITLE
test(vdr): unbreak Windows CI (ColQwen JSON body + missing-Python assertion)

### DIFF
--- a/tests/colqwen_server_http.rs
+++ b/tests/colqwen_server_http.rs
@@ -88,11 +88,18 @@ fn colqwen_server_embeds_image_text_and_caption_inputs() {
     let image = temp.path().join("dog.png");
     fs::write(&image, b"png-bytes").expect("image");
 
-    // When: image, text, and caption inputs are embedded together.
-    let body = format!(
-        r#"{{"model":"vidore/colqwen2-v1.0","dimensions":128,"inputs":[{{"kind":"image","role":"document","value":"{}"}},{{"kind":"text","role":"query","value":"dog"}},{{"kind":"caption","role":"document","value":"a puppy"}}]}}"#,
-        image.display()
-    );
+    // When: image, text, and caption inputs are embedded together. The body
+    // is built with serde_json so Windows paths with backslashes stay valid JSON.
+    let body = serde_json::json!({
+        "model": "vidore/colqwen2-v1.0",
+        "dimensions": 128,
+        "inputs": [
+            {"kind": "image", "role": "document", "value": image.display().to_string()},
+            {"kind": "text", "role": "query", "value": "dog"},
+            {"kind": "caption", "role": "document", "value": "a puppy"}
+        ]
+    })
+    .to_string();
     let response = server.send("application/json", None, &body);
 
     // Then: one 128-d multi-vector is returned per input.

--- a/tests/vdr_auto_start_edges_cli.rs
+++ b/tests/vdr_auto_start_edges_cli.rs
@@ -86,9 +86,15 @@ fn vdr_auto_start_missing_python_path_fails_cleanly() {
 
     assert!(!output.status.success(), "sync should fail");
     let stderr = String::from_utf8_lossy(&output.stderr);
+    // On Windows the default dense backend is ColQwen, so the missing
+    // interpreter is reported by the runtime inspection instead of the spawn.
+    let expected = if cfg!(windows) {
+        "failed to inspect colqwen Python runtime"
+    } else {
+        "failed to start Python interpreter"
+    };
     assert!(
-        stderr.contains("failed to start Python interpreter")
-            && stderr.contains(missing_python.to_str().expect("utf8")),
+        stderr.contains(expected) && stderr.contains(missing_python.to_str().expect("utf8")),
         "expected missing interpreter in error, got: {stderr}"
     );
 }


### PR DESCRIPTION
## Summary

Windows CI on `main` has been red since #27 (runs [34205695835](https://github.com/NomaDamas/ClawGallery/actions/runs/34205695835), [34205724624](https://github.com/NomaDamas/ClawGallery/actions/runs/34205724624)), which also makes every open PR's windows job fail. Two Windows-specific test bugs, unmasked one after the other:

1. **`colqwen_server_embeds_image_text_and_caption_inputs`** interpolated `image.display()` into a raw JSON string. On Windows the temp path's backslashes become invalid JSON escape sequences (`\U`, `\A`, …), the fake server rejects the body with `{"error": "request body must be valid JSON"}`, and the test fails. The body is now built with `serde_json::json!`, so paths are escaped correctly on every platform.
2. **`vdr_auto_start_missing_python_path_fails_cleanly`** (masked by failure 1, since cargo aborts the Windows job at the first failing test target) asserted the MLX spawn error `failed to start Python interpreter`. On Windows the default dense backend is ColQwen (`default_dense_backend()`), so the missing interpreter is instead reported by the runtime inspection as `failed to inspect colqwen Python runtime <path>: os error 2` — equally clean and actionable. The test now asserts the platform-appropriate message; both name the missing interpreter path.

Both are test-only fixes; no production code changes.

## Test plan

- [x] RED: failure 1 on Windows CI on `main` (c3c125f) and PR #28/#29 windows jobs; failure 2 on this branch's first windows job after fixing 1
- [x] Local `cargo fmt` + `cargo test --all-features` green on macOS
- [ ] GREEN: this PR's Windows CI job (both jobs must pass)
