### PR TITLE
fix(folder): normalize paths when matching folder remove

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,6 +219,7 @@ dependencies = [
  "clap",
  "clawgallery-vdr",
  "dirs",
+ "dunce",
  "nucleo-matcher",
  "regex",
  "reqwest",
@@ -320,6 +321,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "equivalent"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.5", features = ["derive"] }
 clawgallery-vdr = { version = "0.2.3", path = "crates/clawgallery-vdr" }
 dirs = "6.0"
+dunce = "1.0"
 nucleo-matcher = "0.3.1"
 regex = "1.12.3"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1057,10 +1057,16 @@ fn undo_rename_records(paths: &AppPaths, args: &RenameArgs) -> Result<Vec<Rename
 
 fn cmd_forget(paths: &AppPaths, args: ForgetArgs) -> Result<()> {
     paths.ensure()?;
-    let requested = fs::canonicalize(&args.file).unwrap_or_else(|_| args.file.clone());
+    // Normalize both sides before comparing so the path form the user typed
+    // matches records stored in any canonical form (issue #22: Windows
+    // \\?\ extended-prefix records must match the plain typed path).
+    let requested = dunce::canonicalize(&args.file).unwrap_or_else(|_| args.file.clone());
     let image = latest_images(paths)?
         .into_iter()
-        .find(|image| image.path == requested)
+        .find(|image| {
+            dunce::simplified(&image.path) == dunce::simplified(&requested)
+                || image.path == args.file
+        })
         .ok_or_else(|| anyhow!("no active image matched {}", args.file.display()))?;
 
     let deleted = if args.delete && image.path.exists() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -517,9 +517,20 @@ fn cmd_folder_add(paths: &AppPaths, args: FolderAddArgs) -> Result<()> {
 
 fn cmd_folder_remove(paths: &AppPaths, args: FolderRemoveArgs) -> Result<()> {
     paths.ensure()?;
+    // Normalize the lookup the same way folder add normalizes what it stores,
+    // so the path form the user typed (no \\?\ prefix, symlinks unresolved)
+    // matches the canonical record (issue #22). dunce::simplified also lets a
+    // plain path match records stored with the prefix by an older release.
+    let requested = dunce::canonicalize(&args.id_or_path).ok();
     let mut matched = false;
     for folder in active_folders(paths)? {
-        if folder.id == args.id_or_path || folder.path.to_string_lossy() == args.id_or_path {
+        let path_matches = requested.as_ref().is_some_and(|requested_path| {
+            dunce::simplified(requested_path) == dunce::simplified(&folder.path)
+        });
+        if folder.id == args.id_or_path
+            || folder.path.to_string_lossy() == args.id_or_path
+            || path_matches
+        {
             let mut removed = folder.clone();
             removed.active = false;
             removed.removed_at = Some(Utc::now());
@@ -2392,8 +2403,10 @@ fn candidate_image_paths(paths: &AppPaths, args: &IngestArgs) -> Result<Vec<Path
 }
 
 fn canonicalize_existing_dir(path: &Path) -> Result<PathBuf> {
+    // dunce strips the Windows \\?\ extended-length prefix that
+    // fs::canonicalize returns, so stored paths match the form users type.
     let canonical =
-        fs::canonicalize(path).with_context(|| format!("{} does not exist", path.display()))?;
+        dunce::canonicalize(path).with_context(|| format!("{} does not exist", path.display()))?;
     if !canonical.is_dir() {
         bail!("{} is not a directory", canonical.display());
     }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1195,6 +1195,29 @@ fn forget_delete_removes_disk_file_and_untracks_image() {
 }
 
 #[test]
+fn forget_file_matches_the_path_form_used_at_index_time() {
+    let temp = tempfile::tempdir().unwrap();
+    let config = temp.path().join("state");
+    let images = temp.path().join("images");
+    fs::create_dir_all(&images).unwrap();
+    let image = images.join("screen.png");
+    fs::write(&image, b"not really png").unwrap();
+    assert_success(run(&config, &["init"]));
+    assert_success(run(
+        &config,
+        &["bootstrap", "--path", images.to_str().unwrap()],
+    ));
+
+    // Forget with the exact string the user typed, never a pre-canonicalized
+    // form (issue #22 comment: forget --file failed to match the stored
+    // Windows \\?\ extended path with the plain typed path).
+    let forgotten = assert_success(run(&config, &["forget", "--file", image.to_str().unwrap()]));
+    assert!(forgotten.contains("forgot 1 image"), "got: {forgotten}");
+    let status = assert_success(run(&config, &["status"]));
+    assert!(status.contains("images: 0"), "got: {status}");
+}
+
+#[test]
 fn forget_missing_path_reports_clear_error() {
     let temp = tempfile::tempdir().unwrap();
     let config = temp.path().join("state");

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -78,6 +78,28 @@ fn folder_bootstrap_search_and_remove_flow() {
     assert!(listed_after.trim().is_empty());
 }
 
+#[test]
+fn folder_remove_matches_the_path_form_used_for_add() {
+    let temp = tempfile::tempdir().unwrap();
+    let config = temp.path().join("state");
+    let images = temp.path().join("images");
+    fs::create_dir_all(&images).unwrap();
+    assert_success(run(&config, &["init"]));
+
+    // Remove with the exact string the user typed for `folder add`, never a
+    // pre-canonicalized form (issue #22: on Windows the stored path carried a
+    // \\?\ prefix while the user types the plain path; on macOS tempdir paths
+    // exercise the same mismatch through /var vs /private/var).
+    let typed = images.to_str().unwrap();
+    assert_success(run(&config, &["folder", "add", typed]));
+    assert_success(run(&config, &["folder", "remove", typed]));
+    let listed = assert_success(run(&config, &["folder", "list"]));
+    assert!(
+        listed.trim().is_empty(),
+        "folder should be removed: {listed}"
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn bootstrap_unchanged_metadata_does_not_read_image_again() {

--- a/tests/cli_hardening.rs
+++ b/tests/cli_hardening.rs
@@ -111,11 +111,13 @@ fn folder_add_duplicate_is_not_noisy() {
     assert_success(run(&config, &["folder", "add", images.to_str().unwrap()]));
     let duplicate = assert_success(run(&config, &["folder", "add", images.to_str().unwrap()]));
 
+    // folder add stores and prints dunce-normalized paths (the Windows
+    // \\?\ prefix is stripped), so the duplicate notice uses the same form.
     assert_eq!(
         duplicate.trim(),
         format!(
             "folder already tracked: {}",
-            images.canonicalize().unwrap().display()
+            dunce::canonicalize(&images).unwrap().display()
         )
     );
 }

--- a/tests/colqwen_server_http.rs
+++ b/tests/colqwen_server_http.rs
@@ -88,11 +88,18 @@ fn colqwen_server_embeds_image_text_and_caption_inputs() {
     let image = temp.path().join("dog.png");
     fs::write(&image, b"png-bytes").expect("image");
 
-    // When: image, text, and caption inputs are embedded together.
-    let body = format!(
-        r#"{{"model":"vidore/colqwen2-v1.0","dimensions":128,"inputs":[{{"kind":"image","role":"document","value":"{}"}},{{"kind":"text","role":"query","value":"dog"}},{{"kind":"caption","role":"document","value":"a puppy"}}]}}"#,
-        image.display()
-    );
+    // When: image, text, and caption inputs are embedded together. The body
+    // is built with serde_json so Windows paths with backslashes stay valid JSON.
+    let body = serde_json::json!({
+        "model": "vidore/colqwen2-v1.0",
+        "dimensions": 128,
+        "inputs": [
+            {"kind": "image", "role": "document", "value": image.display().to_string()},
+            {"kind": "text", "role": "query", "value": "dog"},
+            {"kind": "caption", "role": "document", "value": "a puppy"}
+        ]
+    })
+    .to_string();
     let response = server.send("application/json", None, &body);
 
     // Then: one 128-d multi-vector is returned per input.

--- a/tests/vdr_auto_start_edges_cli.rs
+++ b/tests/vdr_auto_start_edges_cli.rs
@@ -86,9 +86,15 @@ fn vdr_auto_start_missing_python_path_fails_cleanly() {
 
     assert!(!output.status.success(), "sync should fail");
     let stderr = String::from_utf8_lossy(&output.stderr);
+    // On Windows the default dense backend is ColQwen, so the missing
+    // interpreter is reported by the runtime inspection instead of the spawn.
+    let expected = if cfg!(windows) {
+        "failed to inspect colqwen Python runtime"
+    } else {
+        "failed to start Python interpreter"
+    };
     assert!(
-        stderr.contains("failed to start Python interpreter")
-            && stderr.contains(missing_python.to_str().expect("utf8")),
+        stderr.contains(expected) && stderr.contains(missing_python.to_str().expect("utf8")),
         "expected missing interpreter in error, got: {stderr}"
     );
 }


### PR DESCRIPTION
## Summary

`folder add` stored the raw `fs::canonicalize` output, which on Windows carries a `\\?\` extended-length prefix, while `folder remove` compared the user-typed string verbatim — so a folder added as `C:\Users\…\images` could never be removed with that same path (issue #22).

- `canonicalize_existing_dir` now uses `dunce::canonicalize`, which strips the `\\?\` prefix when safe, so newly stored records match the form users type.
- `folder remove` canonicalizes the input and compares `dunce::simplified` forms, which also lets a plain path match records stored **with** the prefix by older releases. The id and exact-string matches stay as fallbacks for folders that no longer exist on disk.
- `forget --file` (reported in [this comment](https://github.com/NomaDamas/ClawGallery/issues/22#issuecomment) on the issue) gets the same treatment: the input is dunce-canonicalized and image records are compared by `dunce::simplified` form with an exact-path fallback, so the typed path matches records stored in any canonical form. Covered by `forget_file_matches_the_path_form_used_at_index_time` (mutation-proven: it fails when `cmd_forget` compares the raw input string).

## Test plan

- [x] New RED→GREEN test `folder_remove_matches_the_path_form_used_for_add`: removes a folder using the exact string passed to `folder add` — pre-fix it failed with `no active folder matched` (reproduced cross-platform via the /var vs /private/var canonicalization gap on macOS, the same defect class as the Windows `\\?\` prefix); post-fix it passes
- [x] Existing `folder_bootstrap_search_and_remove_flow` and full `cargo test --all-features` green (160 passed, 0 failed) + `cargo fmt` / `clippy -D warnings` clean
- [ ] Live QA on the maintainer's Windows 11 host (issue's exact repro: add then remove the same `$HOME\ClawGallery-QA-…\images` path) — host currently offline; will report back once reachable

Closes #22


> **Note for reviewers:** this branch is currently stacked on #30 (the Windows CI test fixes) so its own Windows CI runs green; the diff will shrink to just this fix once #30 merges. Merge order: #30 first.